### PR TITLE
Add keyboard layout for Urdu

### DIFF
--- a/app/src/main/java/rkr/simplekeyboard/inputmethod/keyboard/internal/KeyboardTextsTable.java
+++ b/app/src/main/java/rkr/simplekeyboard/inputmethod/keyboard/internal/KeyboardTextsTable.java
@@ -3769,6 +3769,150 @@ public final class KeyboardTextsTable {
         /* morekeys_cyrillic_ghe */ "\u0491",
     };
 
+    /* Locale ur: Urdu */
+    private static final String[] TEXTS_ur = {
+            /* morekeys_a ~ */
+            null, null, null, null,
+            /* ~ morekeys_u */
+            // Label for "switch to alphabetic" key.
+            // U+0627: "ا" ARABIC LETTER ALEF
+            // U+200C: ZERO WIDTH NON-JOINER
+            // U+0628: "ب" ARABIC LETTER BEH
+            // U+067E: "پ" ARABIC LETTER PEH
+            /* keylabel_to_alpha */ "\u0627\u200C\u0628\u200C\u067E",
+            /* morekeys_i ~ */
+            null, null, null, null, null, null,
+            /* ~ single_quotes */
+            // U+20A8: "₨" RUPEE SIGN
+            /* keyspec_currency */ "\u20A8",
+            /* morekeys_y ~ */
+            null, null, null, null, null, null, null, null, null, null, null, null, null, null, null,
+            null, null, null, null, null,
+            /* ~ morekeys_cyrillic_soft_sign */
+            // U+06F1: "۱" EXTENDED ARABIC-INDIC DIGIT ONE
+            /* keyspec_symbols_1 */ "\u06F1",
+            // U+06F2: "۲" EXTENDED ARABIC-INDIC DIGIT TWO
+            /* keyspec_symbols_2 */ "\u06F2",
+            // U+06F3: "۳" EXTENDED ARABIC-INDIC DIGIT THREE
+            /* keyspec_symbols_3 */ "\u06F3",
+            // U+06F4: "۴" EXTENDED ARABIC-INDIC DIGIT FOUR
+            /* keyspec_symbols_4 */ "\u06F4",
+            // U+06F5: "۵" EXTENDED ARABIC-INDIC DIGIT FIVE
+            /* keyspec_symbols_5 */ "\u06F5",
+            // U+06F6: "۶" EXTENDED ARABIC-INDIC DIGIT SIX
+            /* keyspec_symbols_6 */ "\u06F6",
+            // U+06F7: "۷" EXTENDED ARABIC-INDIC DIGIT SEVEN
+            /* keyspec_symbols_7 */ "\u06F7",
+            // U+06F8: "۸" EXTENDED ARABIC-INDIC DIGIT EIGHT
+            /* keyspec_symbols_8 */ "\u06F8",
+            // U+06F9: "۹" EXTENDED ARABIC-INDIC DIGIT NINE
+            /* keyspec_symbols_9 */ "\u06F9",
+            // U+06F0: "۰" EXTENDED ARABIC-INDIC DIGIT ZERO
+            /* keyspec_symbols_0 */ "\u06F0",
+            // Label for "switch to symbols" key.
+            // U+061F: "؟" ARABIC QUESTION MARK
+            /* keylabel_to_symbol */ "\u06F3\u06F2\u06F1\u061F",
+            /* additional_morekeys_symbols_1 */ "1",
+            /* additional_morekeys_symbols_2 */ "2",
+            /* additional_morekeys_symbols_3 */ "3",
+            /* additional_morekeys_symbols_4 */ "4",
+            /* additional_morekeys_symbols_5 */ "5",
+            /* additional_morekeys_symbols_6 */ "6",
+            /* additional_morekeys_symbols_7 */ "7",
+            /* additional_morekeys_symbols_8 */ "8",
+            /* additional_morekeys_symbols_9 */ "9",
+            // U+066B: "٫" ARABIC DECIMAL SEPARATOR
+            // U+066C: "٬" ARABIC THOUSANDS SEPARATOR
+            /* additional_morekeys_symbols_0 */ "0,\u066B,\u066C",
+            /* morekeys_tablet_period */ "!text/morekeys_arabic_diacritics",
+            /* morekeys_nordic_row2_11 */ null,
+            /* morekeys_punctuation */ null,
+            // U+060C: "،" ARABIC COMMA
+            // U+061B: "؛" ARABIC SEMICOLON
+            // U+061F: "؟" ARABIC QUESTION MARK
+            // U+00AB: "«" LEFT-POINTING DOUBLE ANGLE QUOTATION MARK
+            // U+00BB: "»" RIGHT-POINTING DOUBLE ANGLE QUOTATION MARK
+            /* keyspec_tablet_comma */ "\u060C",
+            /* keyspec_period */ "\u06D4",
+            /* morekeys_period */ "!text/morekeys_arabic_diacritics",
+            /* keyspec_tablet_period */ "\u06D4",
+            null, null, null, null, null, null,
+            /* ~ morekeys_swiss_row2_11 */
+            // U+2605: "★" BLACK STAR
+            // U+066D: "٭" ARABIC FIVE POINTED STAR
+            /* morekeys_star */ "\u2605,\u066D",
+            /* keyspec_left_parenthesis */ "(|)",
+            /* keyspec_right_parenthesis */ ")|(",
+            /* keyspec_left_square_bracket */ "[|]",
+            /* keyspec_right_square_bracket */ "]|[",
+            /* keyspec_left_curly_bracket */ "{|}",
+            /* keyspec_right_curly_bracket */ "}|{",
+            /* keyspec_less_than */ "<|>",
+            /* keyspec_greater_than */ ">|<",
+            /* keyspec_less_than_equal */ "\u2264|\u2265",
+            /* keyspec_greater_than_equal */ "\u2265|\u2264",
+            /* keyspec_left_double_angle_quote */ "\u00AB|\u00BB",
+            /* keyspec_right_double_angle_quote */ "\u00BB|\u00AB",
+            /* keyspec_left_single_angle_quote */ "\u2039|\u203A",
+            /* keyspec_right_single_angle_quote */ "\u203A|\u2039",
+            // U+060C: "،" ARABIC COMMA
+            /* keyspec_comma */ "\u060C",
+            /* morekeys_tablet_comma */ "!fixedColumnOrder!4,:,!,\u061F,\u061B,-,!text/keyspec_left_double_angle_quote,!text/keyspec_right_double_angle_quote",
+            // U+064B: "ً" ARABIC FATHATAN
+            /* keyhintlabel_period */ "\u064B",
+            // U+00BF: "¿" INVERTED QUESTION MARK
+            /* morekeys_question */ "?,\u00BF",
+            /* morekeys_h ~ */
+            null, null, null, null, null, null, null, null, null, null, null, null, null, null,
+            /* ~ keyspec_spanish_row2_10 */
+            // U+266A: "♪" EIGHTH NOTE
+            /* morekeys_bullet */ "\u266A",
+            // The all letters need to be mirrored are found at
+            // http://www.unicode.org/Public/6.1.0/ucd/BidiMirroring.txt
+            // U+FD3E: "﴾" ORNATE LEFT PARENTHESIS
+            // U+FD3F: "﴿" ORNATE RIGHT PARENTHESIS
+            /* morekeys_left_parenthesis */ "!fixedColumnOrder!4,\uFD3E|\uFD3F,!text/keyspecs_left_parenthesis_more_keys",
+            /* morekeys_right_parenthesis */ "!fixedColumnOrder!4,\uFD3F|\uFD3E,!text/keyspecs_right_parenthesis_more_keys",
+            // U+061F: "؟" ARABIC QUESTION MARK
+            // U+0021: "!" EXCLAMATION MARK
+            // U+064F: "ُ" ARABIC DAMMA
+            // U+0650: "ِ" ARABIC KASRA
+            // U+064E: "َ" ARABIC FATHA
+            // U+0652: "ْ" ARABIC SUKUN
+            // U+0651: "ّ" ARABIC SHADDA
+            // U+064C: "ٌ" ARABIC DAMMATAN
+            // U+064D: "ٍ" ARABIC KASRATAN
+            // U+064B: "ً" ARABIC FATHATAN
+            // U+0658: "٘" ARABIC MARK NOON GHUNNA
+            // U+0654: "ٔ" ARABIC HAMZA ABOVE
+            // U+0657: "ٗ" ARABIC INVERTED DAMMA
+            // U+0656: "ٖ" ARABIC SUBSCRIPT ALEF
+            // U+0670: "ٰ" ARABIC LETTER SUPERSCRIPT ALEF
+            // Note: The space character is needed as a preceding letter to draw Arabic diacritics characters correctly.
+            /* morekeys_arabic_diacritics */ "!fixedColumnOrder!5,\u061F|\u061F,\u0021|\u0021, \u064F|\u064F, \u0650|\u0650, \u064E|\u064E, \u0652|\u0652, \u0651|\u0651, \u064C|\u064C, \u064D|\u064D, \u064B|\u064B, \u0658|\u0658, \u0654|\u0654, \u0657|\u0657, \u0656|\u0656, \u0670|\u0670",
+            /* keyhintlabel_tablet_comma */ "\u061F",
+            /* keyhintlabel_tablet_period */ "\u064B",
+            /* keyspec_symbols_question */ "\u061F",
+            /* keyspec_symbols_semicolon */ "\u061B",
+            // U+066A: "٪" ARABIC PERCENT SIGN
+            /* keyspec_symbols_percent */ "\u066A",
+            /* morekeys_symbols_semicolon */ ";",
+            // U+2030: "‰" PER MILLE SIGN
+            /* morekeys_symbols_percent */ "\\%,\u2030",
+            /* label_go_key ~ */
+            null, null, null, null, null, null, null, null, null, null, null, null, null, null, null,
+            null, null, null, null, null, null,
+            /* ~ morekeys_plus */
+            // U+2264: "≤" LESS-THAN OR EQUAL TO
+            // U+2265: "≥" GREATER-THAN EQUAL TO
+            // U+00AB: "«" LEFT-POINTING DOUBLE ANGLE QUOTATION MARK
+            // U+00BB: "»" RIGHT-POINTING DOUBLE ANGLE QUOTATION MARK
+            // U+2039: "‹" SINGLE LEFT-POINTING ANGLE QUOTATION MARK
+            // U+203A: "›" SINGLE RIGHT-POINTING ANGLE QUOTATION MARK
+            /* morekeys_less_than */ "!fixedColumnOrder!3,!text/keyspec_left_single_angle_quote,!text/keyspec_less_than_equal,!text/keyspec_less_than",
+            /* morekeys_greater_than */ "!fixedColumnOrder!3,!text/keyspec_right_single_angle_quote,!text/keyspec_greater_than_equal,!text/keyspec_greater_than",
+    };
+
     /* Locale uz_UZ: Uzbek (Uzbekistan) */
     private static final String[] TEXTS_uz_UZ = {
         // This is the same as Turkish
@@ -4170,6 +4314,7 @@ public final class KeyboardTextsTable {
         "tl"     , TEXTS_tl,    /*   7/  8 Tagalog */
         "tr"     , TEXTS_tr,    /*  11/ 18 Turkish */
         "uk"     , TEXTS_uk,    /*  11/ 91 Ukrainian */
+        "ur"     , TEXTS_ur,    /*  58/133 Urdu */
         "uz_UZ"  , TEXTS_uz_UZ, /*  11/ 18 Uzbek (Uzbekistan) */
         "vi"     , TEXTS_vi,    /*   8/ 15 Vietnamese */
         "zu"     , TEXTS_zu,    /*   8/ 10 Zulu */

--- a/app/src/main/res/values-ur-rPK/strings.xml
+++ b/app/src/main/res/values-ur-rPK/strings.xml
@@ -59,10 +59,10 @@
     <string name="prefs_keypress_sound_volume_settings">"کلید دبانے پر آواز کا والیوم"</string>
     <string name="prefs_key_longpress_timeout_settings">"کلید کو دیر تک دبانے کی تاخیر"</string>
     <string name="button_default">"ڈیفالٹ"</string>
-    <string name="prefs_keyboard_height_settings">Keyboard height</string>
-    <string name="keyboard_color">Set custom keyboard color</string>
-    <string name="hide_special_chars">Hide special characters</string>
-    <string name="hide_language_switch_key">Hide language switch key</string>
-    <string name="show_number_row">Show separate number row</string>
-    <string name="space_swipe">Space swipe cursor move</string>
+    <string name="prefs_keyboard_height_settings">کی بورڈ کی اونچائی</string>
+    <string name="keyboard_color">کی بورڈ کا کسٹم رنگ منتخب کریں</string>
+    <string name="hide_special_chars">سپیشل حروف کو چُھپائیں</string>
+    <string name="hide_language_switch_key">زبان تبدیل کرنے کی کلید کو چُھپائیں</string>
+    <string name="show_number_row">اعداد کے لیے علاحدہ قطار دکھائیں</string>
+    <string name="space_swipe">سپیس کلید پر سوائپ سے کرسر کی حرکت</string>
 </resources>

--- a/app/src/main/res/xml-sw600dp/key_space_7kw.xml
+++ b/app/src/main/res/xml-sw600dp/key_space_7kw.xml
@@ -23,7 +23,7 @@
     >
     <switch>
         <case
-            latin:keyboardLayoutSet="bengali_akkhor|farsi|kannada|nepali_romanized|nepali_traditional|telugu"
+            latin:keyboardLayoutSet="bengali_akkhor|farsi|kannada|nepali_romanized|nepali_traditional|urdu|telugu"
             latin:languageSwitchKeyEnabled="true"
             >
             <Key
@@ -35,7 +35,7 @@
                 latin:keyStyle="zwnjKeyStyle" />
         </case>
         <case
-            latin:keyboardLayoutSet="bengali_akkhor|farsi|kannada|nepali_romanized|nepali_traditional|telugu"
+            latin:keyboardLayoutSet="bengali_akkhor|farsi|kannada|nepali_romanized|nepali_traditional|urdu|telugu"
             latin:languageSwitchKeyEnabled="false"
             >
             <Key

--- a/app/src/main/res/xml-sw600dp/rows_urdu.xml
+++ b/app/src/main/res/xml-sw600dp/rows_urdu.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+/*
+**
+** Copyright 2012, The Android Open Source Project
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+-->
+
+<merge xmlns:latin="http://schemas.android.com/apk/res/rkr.simplekeyboard.inputmethod">
+    <include latin:keyboardLayout="@xml/key_styles_common" />
+    <Row>
+        <include
+            latin:keyboardLayout="@xml/rowkeys_urdu1"
+            latin:keyWidth="9.0%p" />
+        <Key
+            latin:keyStyle="deleteKeyStyle"
+            latin:keyWidth="fillRight" />
+    </Row>
+    <Row>
+        <include
+            latin:keyboardLayout="@xml/rowkeys_urdu2"
+            latin:keyXPos="4.5%p"
+            latin:keyWidth="9.0%p" />
+        <Key
+            latin:keyStyle="enterKeyStyle"
+            latin:keyWidth="fillRight" />
+    </Row>
+    <Row>
+        <Key
+            latin:keyStyle="shiftKeyStyle"
+            latin:keyWidth="10.0%p" />
+        <include
+            latin:keyboardLayout="@xml/rowkeys_urdu3"
+            latin:keyWidth="9.0%p" />
+        <Key
+            latin:keySpec="!"
+            latin:moreKeys="!text/morekeys_exclamation"
+            latin:keyWidth="9.0%p" />
+        <Key
+            latin:keySpec="!text/keyspec_symbols_question"
+            latin:moreKeys="!text/morekeys_question"
+            latin:keyWidth="9.0%p" />
+        <Key
+            latin:keyStyle="shiftKeyStyle"
+            latin:keyWidth="fillRight" />
+    </Row>
+    <include latin:keyboardLayout="@xml/row_qwerty4" />
+</merge>

--- a/app/src/main/res/xml/kbd_urdu.xml
+++ b/app/src/main/res/xml/kbd_urdu.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+/*
+**
+** Copyright 2012, The Android Open Source Project
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+-->
+
+<Keyboard
+    xmlns:latin="http://schemas.android.com/apk/res/rkr.simplekeyboard.inputmethod"
+>
+    <include
+        latin:keyboardLayout="@xml/rows_urdu" />
+</Keyboard>

--- a/app/src/main/res/xml/key_space_5kw.xml
+++ b/app/src/main/res/xml/key_space_5kw.xml
@@ -23,7 +23,7 @@
     >
     <switch>
         <case
-            latin:keyboardLayoutSet="bengali_akkhor|farsi|kannada|nepali_romanized|nepali_traditional|telugu"
+            latin:keyboardLayoutSet="bengali_akkhor|farsi|kannada|nepali_romanized|nepali_traditional|urdu|telugu"
             latin:languageSwitchKeyEnabled="true"
             >
             <Key
@@ -35,7 +35,7 @@
                 latin:keyStyle="zwnjKeyStyle" />
         </case>
         <case
-            latin:keyboardLayoutSet="bengali_akkhor|farsi|kannada|nepali_romanized|nepali_traditional|telugu"
+            latin:keyboardLayoutSet="bengali_akkhor|farsi|kannada|nepali_romanized|nepali_traditional|urdu|telugu"
             latin:languageSwitchKeyEnabled="false"
             >
             <Key

--- a/app/src/main/res/xml/key_styles_currency.xml
+++ b/app/src/main/res/xml/key_styles_currency.xml
@@ -87,6 +87,7 @@
              ne: Nepali (Nepalese Rupee)
              th: Thai (Baht)
              uk: Ukrainian (Hryvnia)
+             ur: Pakistan (Pakistani Rupee)
              vi: Vietnamese (Dong)  -->
         <!-- TODO: The currency sign of Turkish Lira was created in 2012 and assigned U+20BA for
              its unicode, although there is no font glyph for it as of November 2012. -->
@@ -94,7 +95,7 @@
              its unicode, although there is no font glyph for it as of September 2013. -->
         <!-- TODO: The currency sign of Russian Ruble was created in 2014 and assigned U+20BD for
              its unicode, although there is no font glyph for it as of August 2014. -->
-        <case latin:languageCode="fa|hi|iw|lo|mn|ne|th|uk|vi">
+        <case latin:languageCode="fa|hi|iw|lo|mn|ne|th|uk|ur|vi">
             <include latin:keyboardLayout="@xml/key_styles_currency_generic" />
         </case>
         <!-- si_LK: Sinhala (Sri Lanka) (Sri Lanka Rupee)

--- a/app/src/main/res/xml/keyboard_layout_set_urdu.xml
+++ b/app/src/main/res/xml/keyboard_layout_set_urdu.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+/*
+**
+** Copyright 2012, The Android Open Source Project
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+-->
+
+<KeyboardLayoutSet
+    xmlns:latin="http://schemas.android.com/apk/res/rkr.simplekeyboard.inputmethod">
+    <Element
+        latin:elementName="alphabet"
+        latin:elementKeyboard="@xml/kbd_urdu"
+        latin:enableProximityCharsCorrection="true" />
+    <Element
+        latin:elementName="symbols"
+        latin:elementKeyboard="@xml/kbd_symbols" />
+    <Element
+        latin:elementName="symbolsShifted"
+        latin:elementKeyboard="@xml/kbd_symbols_shift" />
+    <Element
+        latin:elementName="phone"
+        latin:elementKeyboard="@xml/kbd_phone" />
+    <Element
+        latin:elementName="phoneSymbols"
+        latin:elementKeyboard="@xml/kbd_phone_symbols" />
+    <Element
+        latin:elementName="number"
+        latin:elementKeyboard="@xml/kbd_number" />
+</KeyboardLayoutSet>

--- a/app/src/main/res/xml/method.xml
+++ b/app/src/main/res/xml/method.xml
@@ -100,6 +100,7 @@
     tl: Tagalog/spanish
     tr: Turkish/qwerty
     uk: Ukrainian/east_slavic
+    ur: Urdu/urdu
     uz_UZ: Uzbek (Uzbekistan)/uzbek # This is a preliminary keyboard layout.
     vi: Vietnamese/qwerty
     zu: Zulu/qwerty
@@ -718,6 +719,13 @@
             android:imeSubtypeMode="keyboard"
             android:imeSubtypeExtraValue="KeyboardLayoutSet=east_slavic"
             android:isAsciiCapable="false"
+    />
+    <subtype android:icon="@drawable/ic_ime_switcher_dark"
+        android:label="@string/subtype_generic"
+        android:imeSubtypeLocale="ur"
+        android:imeSubtypeMode="keyboard"
+        android:imeSubtypeExtraValue="KeyboardLayoutSet=urdu"
+        android:isAsciiCapable="false"
     />
     <!-- TODO: This Uzbek keyboard is a preliminary layout.
                This isn't based on the final specification. -->

--- a/app/src/main/res/xml/rowkeys_urdu1.xml
+++ b/app/src/main/res/xml/rowkeys_urdu1.xml
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+/*
+**
+** Copyright 2012, The Android Open Source Project
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+-->
+
+<merge xmlns:latin="http://schemas.android.com/apk/res/rkr.simplekeyboard.inputmethod">
+    <switch>
+        <case latin:keyboardLayoutSetElement="alphabetManualShifted|alphabetShiftLocked|alphabetShiftLockShifted">
+            <!-- U+0654: "ٔ" ARABIC HAMZA ABOVE -->
+            <Key latin:keySpec="&#x0654;" />
+            <!-- U+0652: "ْ" ARABIC SUKUN -->
+            <Key latin:keySpec="&#x0652;" />
+            <!-- U+0651: "ّ" ARABIC SHADDA -->
+            <Key latin:keySpec="&#x0651;" />
+            <!-- U+064B: "ً" ARABIC FATHATAN -->
+            <Key latin:keySpec="&#x064B;" />
+            <!-- U+0657: "ٗ" ARABIC INVERTED DAMMA -->
+            <Key latin:keySpec="&#x0657;" />
+            <!-- U+0656: "ٖ" ARABIC SUBSCRIPT ALEF  -->
+            <Key latin:keySpec="&#x0656;" />
+            <!-- U+0670: "ٰ" ARABIC LETTER SUPERSCRIPT ALEF  -->
+            <Key latin:keySpec="&#x0670;" />
+            <!-- U+064F: "ُ" ARABIC DAMMA  -->
+            <Key latin:keySpec="&#x064F;" />
+            <!-- U+0650: "ِ" ARABIC KASRA  -->
+            <Key latin:keySpec="&#x0650;" />
+            <!-- U+064E: "َ" ARABIC FATHA  -->
+            <Key latin:keySpec="&#x064E;" />
+        </case>
+        <default>
+            <!-- U+0642: "ق" ARABIC LETTER QAF -->
+            <Key latin:keySpec="&#x0642;" />
+            <!-- U+0648: "و" ARABIC LETTER WAW
+                 U+0624: "ؤ" ARABIC LETTER WAW WITH HAMZA ABOVE -->
+            <Key
+                latin:keySpec="&#x0648;"
+                latin:keyHintLabel="&#x0624;"
+                latin:additionalMoreKeys="&#x0624;" />
+            <!-- U+0639: "ع" ARABIC LETTER AIN -->
+            <Key latin:keySpec="&#x0639;" />
+            <!-- U+0631: "ر" ARABIC LETTER REH
+                 U+0691: "ڑ" ARABIC LETTER RREH -->
+            <Key
+                latin:keySpec="&#x0631;"
+                latin:keyHintLabel="&#x0691;"
+                latin:additionalMoreKeys="&#x0691;" />
+            <!-- U+062A: "ت" ARABIC LETTER TEH
+                 U+0679: "ٹ" ARABIC LETTER TTEH -->
+            <Key
+                latin:keySpec="&#x062A;"
+                latin:keyHintLabel="&#x0679;"
+                latin:additionalMoreKeys="&#x0679;" />
+            <!-- U+06D2: "ے" ARABIC LETTER YEH BARREE
+                 U+06D3: "ۓ" ARABIC LETTER YEH BARREE WITH HAMZA ABOVE -->
+            <Key
+                latin:keySpec="&#x06D2;"
+                latin:keyHintLabel="&#x06D3;"
+                latin:additionalMoreKeys="&#x06D3;" />
+            <!-- U+0621: "ء" ARABIC LETTER HAMZA
+                 U+0626: "ئ" ARABIC LETTER YEH WITH HAMZA ABOVE -->
+            <Key
+                latin:keySpec="&#x0621;"
+                latin:keyHintLabel="&#x0626;"
+                latin:additionalMoreKeys="&#x0626;" />
+            <!-- U+06CC: "ی" ARABIC LETTER FARSI YEH -->
+            <Key latin:keySpec="&#x06CC;" />
+            <!-- U+06C1: "ہ" ARABIC LETTER HEH GOAL
+                 U+06C2: "ۂ" ARABIC LETTER HEH GOAL WITH HAMZA ABOVE
+                 U+06C3: "ۃ" ARABIC LETTER TEH MARTUBA GOAL -->
+            <Key
+                latin:keySpec="&#x06C1;"
+                latin:keyHintLabel="&#x06C2;"
+                latin:additionalMoreKeys="&#x06C2;,&#x06C3;" />
+            <!-- U+067E: "پ" ARABIC LETTER PEH -->
+            <Key latin:keySpec="&#x067E;" />
+        </default>
+    </switch>
+</merge>

--- a/app/src/main/res/xml/rowkeys_urdu2.xml
+++ b/app/src/main/res/xml/rowkeys_urdu2.xml
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+/*
+**
+** Copyright 2012, The Android Open Source Project
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+-->
+
+<merge xmlns:latin="http://schemas.android.com/apk/res/rkr.simplekeyboard.inputmethod">
+    <switch>
+        <case latin:keyboardLayoutSetElement="alphabetManualShifted|alphabetShiftLocked|alphabetShiftLockShifted">
+            <!-- U+060F: "؏" ARABIC SIGN MISRA -->
+            <Key latin:keySpec="&#x060F;" />
+            <!-- U+060E: "؎" ARABIC POETIC VERSE SIGN -->
+            <Key latin:keySpec="&#x060E;" />
+            <!-- U+0614: "ؔ" ARABIC SIGN TAKHALLUS -->
+            <Key latin:keySpec="&#x0614;" />
+            <!-- U+0612: "ؒ" ARABIC SIGN RAHMATULLAH ALAYHE -->
+            <Key latin:keySpec="&#x0612;" />
+            <!-- U+0613: "ؓ" ARABIC SIGN RADI ALLAHOU ANHU -->
+            <Key latin:keySpec="&#x0613;" />
+            <!-- U+0611: "ؑ" ARABIC SIGN ALAYHE ASSALLAM -->
+            <Key latin:keySpec="&#x0611;" />
+            <!-- U+0610: "ؐ" ARABIC SIGN SALLALLAHOU ALAYHE WASSALLAM -->
+            <Key latin:keySpec="&#x0610;" />
+            <!-- U+FDFA: "ﷺ" ARABIC LIGATURE SALLALLAHOU ALAYHE WASALLAM -->
+            <Key latin:keySpec="&#xFDFA;" />
+            <!-- U+FDFB: "ﷻ" ARABIC LIGATURE JALLAJALALOUHOU -->
+            <Key latin:keySpec="&#xFDFB;" />
+        </case>
+        <default>
+            <!-- U+0627: "ا" ARABIC LETTER ALEF
+                 U+0622: "آ" ARABIC LETTER ALEF WITH MADDA ABOVE
+                 U+0623: "أ" ARABIC LETTER ALEF WITH HAMZA ABOVE -->
+            <Key
+                latin:keySpec="&#x0627;"
+                latin:keyHintLabel="&#x0622;"
+                latin:moreKeys="&#x0622;,&#x0623;" />
+            <!-- U+0633: "س" ARABIC LETTER SEEN
+                 U+0635: "ص" ARABIC LETTER SAD -->
+            <Key
+                latin:keySpec="&#x0633;"
+                latin:keyHintLabel="&#x0635;"
+                latin:moreKeys="&#x0635;" />
+            <!-- U+062F: "د" ARABIC LETTER DAL
+                 U+0688: "ڈ" ARABIC LETTER DDAL -->
+            <Key
+                latin:keySpec="&#x062F;"
+                latin:keyHintLabel="&#x0688;"
+                latin:moreKeys="&#x0688;" />
+            <!-- U+0641: "ف" ARABIC LETTER FEH -->
+            <Key latin:keySpec="&#x0641;" />
+            <!-- U+06AF: "گ" ARABIC LETTER GAF
+                 U+063A: "غ" ARABIC LETTER GHAIN -->
+            <Key
+                latin:keySpec="&#x06AF;"
+                latin:keyHintLabel="&#x063A;"
+                latin:moreKeys="&#x063A;" />
+            <!-- U+062D: "ح" ARABIC LETTER HAH
+                 U+06BE: "ھ" ARABIC LETTER DOACHASHMEE -->
+            <Key
+                latin:keySpec="&#x062D;"
+                latin:keyHintLabel="&#x06BE;"
+                latin:moreKeys="&#x06BE;" />
+            <!-- U+062C: "ج" ARABIC LETTER JEEM
+                 U+0636: "ض": ARABIC LETTER DAD -->
+            <Key
+                latin:keySpec="&#x062C;"
+                latin:keyHintLabel="&#x0636;"
+                latin:moreKeys="&#x0636;" />
+            <!-- U+06A9: "ک" ARABIC LETTER KEHEH
+                 U+062E: "خ" ARABIC LETTER KHAH -->
+            <Key
+                latin:keySpec="&#x06A9;"
+                latin:keyHintLabel="&#x062E;"
+                latin:moreKeys="&#x062E;" />
+            <!-- U+0644: "ل" ARABIC LETTER LAM -->
+            <Key latin:keySpec="&#x0644;" />
+        </default>
+    </switch>
+</merge>

--- a/app/src/main/res/xml/rowkeys_urdu3.xml
+++ b/app/src/main/res/xml/rowkeys_urdu3.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+/*
+**
+** Copyright 2012, The Android Open Source Project
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+-->
+
+<merge xmlns:latin="http://schemas.android.com/apk/res/rkr.simplekeyboard.inputmethod">
+    <switch>
+        <case latin:keyboardLayoutSetElement="alphabetManualShifted|alphabetShiftLocked|alphabetShiftLockShifted">
+            <!-- U+0601: "؁" ARABIC SIGN SANAH -->
+            <Key latin:keySpec="&#x0601;" />
+            <!-- U+0600: "" ARABIC NUMBER SIGN -->
+            <Key latin:keySpec="&#x0600;" />
+            <!-- U+0602: "؂" ARABIC FOOTNOTE MARKER -->
+            <Key latin:keySpec="&#x0602;" />
+            <!-- U+0603: "؃" ARABIC SIGN SAFHA -->
+            <Key latin:keySpec="&#x0603;" />
+            <!-- U+060D: "؍" ARABIC DATE SEPARATOR -->
+            <Key latin:keySpec="&#x060D;" />
+            <!-- U+0658: "٘" ARABIC MARK NOON GHUNNA -->
+            <Key latin:keySpec="&#x0658;" />
+            <!-- U+066B: "٫" ARABIC DECIMAL SEPARATOR -->
+            <Key latin:keySpec="&#x066B;" />
+        </case>
+        <default>
+            <!-- U+0632: "ز" ARABIC LETTER ZAIN
+                 U+0630: "ذ" ARABIC LETTER THAL -->
+            <Key
+                latin:keySpec="&#x0632;"
+                latin:keyHintLabel="&#x0630;"
+                latin:moreKeys="&#x0630;" />
+            <!-- U+0634: "ش" ARABIC LETTER SHEEN
+                 U+0698: "ژ" ARABIC LETTER JEH -->
+            <Key
+                latin:keySpec="&#x0634;"
+                latin:keyHintLabel="&#x0698;"
+                latin:moreKeys="&#x0698;" />
+            <!-- U+0686: "چ" ARABIC LETTER TCHEH
+                 U+062B: "ث" ARABIC LETTER THEH -->
+            <Key
+                latin:keySpec="&#x0686;"
+                latin:keyHintLabel="&#x062B;"
+                latin:moreKeys="&#x062B;" />
+            <!-- U+0637: "ط" ARABIC LETTER TAH
+                 U+0638: "ظ" ARABIC LETTER ZAH -->
+            <Key
+                latin:keySpec="&#x0637;"
+                latin:keyHintLabel="&#x0638;"
+                latin:moreKeys="&#x0638;" />
+            <!-- U+0628: "ب" ARABIC LETTER BEH -->
+            <Key latin:keySpec="&#x0628;" />
+            <!-- U+0646: "ن" ARABIC LETTER NOON
+                 U+06BA: "ں" ARABIC LETTER NOON GHUNNA -->
+            <Key
+                latin:keySpec="&#x0646;"
+                latin:keyHintLabel="&#x06BA;"
+                latin:moreKeys="&#x06BA;" />
+            <!-- U+0645: "م" ARABIC LETTER MEEM -->
+            <Key latin:keySpec="&#x0645;" />
+        </default>
+    </switch>
+</merge>

--- a/app/src/main/res/xml/rows_urdu.xml
+++ b/app/src/main/res/xml/rows_urdu.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+/*
+**
+** Copyright 2012, The Android Open Source Project
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+-->
+
+<merge xmlns:latin="http://schemas.android.com/apk/res/rkr.simplekeyboard.inputmethod">
+    <include latin:keyboardLayout="@xml/key_styles_common" />
+    <Row
+        latin:keyWidth="10%p"
+        latin:keyLabelFlags="fontNormal"
+    >
+        <include latin:keyboardLayout="@xml/rowkeys_urdu1" />
+    </Row>
+    <Row
+        latin:keyWidth="10%p"
+        latin:keyLabelFlags="fontNormal"
+    >
+        <include
+            latin:keyboardLayout="@xml/rowkeys_urdu2"
+            latin:keyXPos="5%p" />
+    </Row>
+    <Row
+        latin:keyWidth="10%p"
+        latin:keyLabelFlags="fontNormal"
+    >
+        <Key
+            latin:keyStyle="shiftKeyStyle"
+            latin:keyWidth="15%p"
+            latin:visualInsetsRight="1%p" />
+        <include latin:keyboardLayout="@xml/rowkeys_urdu3" />
+        <Key
+            latin:keyStyle="deleteKeyStyle"
+            latin:keyWidth="fillRight" />
+    </Row>
+    <include latin:keyboardLayout="@xml/row_qwerty4" />
+</merge>


### PR DESCRIPTION
This PR adds a layout for Urdu.

Note: The file `KeyboardTextsTable.java` states that it shouldn't be edited manually. However, the tools required to generate that file require the AOSP code and are not present in Simple Keyboard. Therefore, I took the liberty of editing it manually anyway. (The count of texts at the end of the file is also not accurate, but they are stated in comments for informational purposes.)