### PR TITLE
added configurations for an english alphabet layout

### DIFF
--- a/app/src/main/res/values/donottranslate.xml
+++ b/app/src/main/res/values/donottranslate.xml
@@ -50,6 +50,7 @@
         <item>dvorak</item>
         <item>colemak</item>
         <item>pcqwerty</item>
+        <item>alphabet</item>
     </string-array>
     <!-- Predefined keyboard layout display names -->
     <string-array name="predefined_layout_display_names">
@@ -59,6 +60,7 @@
         <item>Dvorak</item>
         <item>Colemak</item>
         <item>PC</item>
+        <item>ALPHABET</item>
     </string-array>
     <!-- Description for generic subtype that has predefined layout.
          The string resource name must be "subtype_generic_<layout name>".
@@ -70,6 +72,7 @@
     <string name="subtype_generic_dvorak">%s (Dvorak)</string>
     <string name="subtype_generic_colemak">%s (Colemak)</string>
     <string name="subtype_generic_pcqwerty">%s (PC)</string>
+    <string name="subtype_generic_alphabet">%s (ALPHABET)</string>
 
     <!-- Description for Bulgarian (BDS) subtype. -->
     <string name="subtype_bulgarian_bds">%s (BDS)</string>

--- a/app/src/main/res/xml/kbd_alphabet.xml
+++ b/app/src/main/res/xml/kbd_alphabet.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+/*
+**
+** Copyright 2008, The Android Open Source Project
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+-->
+
+<Keyboard xmlns:latin="http://schemas.android.com/apk/res-auto">
+    <include
+        latin:keyboardLayout="@xml/key_styles_common" />
+
+    <switch>
+        <case latin:showNumberRow="true">
+            <include latin:keyboardLayout="@xml/rowkeys_alphabet0" />
+
+            <include
+                latin:keyboardLayout="@xml/rows_alphabet"
+                latin:rowHeight="21.25%p" />
+        </case>
+        <default>
+            <include latin:keyboardLayout="@xml/rows_alphabet" />
+        </default>
+    </switch>
+</Keyboard>

--- a/app/src/main/res/xml/keyboard_layout_set_alphabet.xml
+++ b/app/src/main/res/xml/keyboard_layout_set_alphabet.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+/*
+**
+** Copyright 2012, The Android Open Source Project
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+-->
+
+<KeyboardLayoutSet
+    xmlns:latin="http://schemas.android.com/apk/res-auto">
+    <Element
+        latin:elementName="alphabet"
+        latin:elementKeyboard="@xml/kbd_alphabet"
+        latin:enableProximityCharsCorrection="true" />
+    <Element
+        latin:elementName="symbols"
+        latin:elementKeyboard="@xml/kbd_symbols" />
+    <Element
+        latin:elementName="symbolsShifted"
+        latin:elementKeyboard="@xml/kbd_symbols_shift" />
+    <Element
+        latin:elementName="phone"
+        latin:elementKeyboard="@xml/kbd_phone" />
+    <Element
+        latin:elementName="phoneSymbols"
+        latin:elementKeyboard="@xml/kbd_phone_symbols" />
+    <Element
+        latin:elementName="number"
+        latin:elementKeyboard="@xml/kbd_number" />
+</KeyboardLayoutSet>

--- a/app/src/main/res/xml/row_alphabet4.xml
+++ b/app/src/main/res/xml/row_alphabet4.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+/*
+**
+** Copyright 2010, The Android Open Source Project
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+-->
+
+<merge
+    xmlns:latin="http://schemas.android.com/apk/res-auto"
+>
+    <Row
+        latin:keyWidth="10%p"
+    >
+        <Key
+            latin:keyStyle="toSymbolKeyStyle"
+            latin:keyWidth="15%p" />
+        <include
+            latin:keyboardLayout="@xml/key_comma" />
+        <include
+            latin:keyXPos="25%p"
+            latin:keyboardLayout="@xml/key_space_5kw" />
+        <include
+            latin:keyboardLayout="@xml/key_period" />
+        <Key
+            latin:keyStyle="enterKeyStyle"
+            latin:keyWidth="fillRight" />
+    </Row>
+</merge>

--- a/app/src/main/res/xml/rowkeys_alphabet0.xml
+++ b/app/src/main/res/xml/rowkeys_alphabet0.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+/*
+**
+** Copyright 2012, The Android Open Source Project
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+-->
+
+<merge xmlns:latin="http://schemas.android.com/apk/res-auto">
+    <Row
+        latin:rowHeight="15%p"
+        >
+        <Key
+            latin:keySpec="1" />
+        <Key
+            latin:keySpec="2" />
+        <Key
+            latin:keySpec="3" />
+        <Key
+            latin:keySpec="4" />
+        <Key
+            latin:keySpec="5" />
+        <Key
+            latin:keySpec="6" />
+        <Key
+            latin:keySpec="7" />
+        <Key
+            latin:keySpec="8" />
+        <Key
+            latin:keySpec="9" />
+        <Key
+            latin:keySpec="0" />
+    </Row>
+</merge>

--- a/app/src/main/res/xml/rowkeys_alphabet1.xml
+++ b/app/src/main/res/xml/rowkeys_alphabet1.xml
@@ -1,0 +1,108 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+/*
+**
+** Copyright 2012, The Android Open Source Project
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+-->
+
+<merge
+    xmlns:latin="http://schemas.android.com/apk/res-auto"
+>
+    <switch>
+        <case latin:showNumberRow="true">
+            <Key
+                latin:keySpec="a"
+                latin:moreKeys="!text/morekeys_a" />
+            <Key
+                latin:keySpec="b" />
+            <Key
+                latin:keySpec="c"
+                latin:moreKeys="!text/morekeys_c" />
+            <Key
+                latin:keySpec="d"
+                latin:moreKeys="!text/morekeys_d" />
+            <Key
+                latin:keySpec="e"
+                latin:moreKeys="!text/morekeys_e" />
+            <Key
+                latin:keySpec="f" />
+            <Key
+                latin:keySpec="g"
+                latin:moreKeys="!text/morekeys_g" />
+            <Key
+                latin:keySpec="h"
+                latin:moreKeys="!text/morekeys_h" />
+            <Key
+                latin:keySpec="i"
+                latin:moreKeys="!text/morekeys_i" />
+            <Key
+                latin:keySpec="j"
+                latin:moreKeys="!text/morekeys_j" />
+        </case>
+        <default>
+            <Key
+                latin:keySpec="a"
+                latin:keyHintLabel="1"
+                latin:additionalMoreKeys="1"
+                latin:moreKeys="!text/morekeys_a" />
+            <Key
+                latin:keySpec="b" 
+                latin:keyHintLabel="2"
+                latin:additionalMoreKeys="2"
+                />
+            <Key
+                latin:keySpec="c"
+                latin:keyHintLabel="3"
+                latin:additionalMoreKeys="3"
+                latin:moreKeys="!text/morekeys_c" />
+            <Key
+                latin:keySpec="d"
+                latin:keyHintLabel="4"
+                latin:additionalMoreKeys="4"
+                latin:moreKeys="!text/morekeys_d" />
+            <Key
+                latin:keySpec="e"
+                latin:keyHintLabel="5"
+                latin:additionalMoreKeys="5"
+                latin:moreKeys="!text/morekeys_e" />
+            <Key
+                latin:keySpec="f" 
+                latin:keyHintLabel="6"
+                latin:additionalMoreKeys="6"
+                />
+            <Key
+                latin:keySpec="g"
+                latin:keyHintLabel="7"
+                latin:additionalMoreKeys="7"
+                latin:moreKeys="!text/morekeys_g" />
+            <Key
+                latin:keySpec="h"
+                latin:keyHintLabel="8"
+                latin:additionalMoreKeys="8"
+                latin:moreKeys="!text/morekeys_h" />
+            <Key
+                latin:keySpec="i"
+                latin:keyHintLabel="9"
+                latin:additionalMoreKeys="9"
+                latin:moreKeys="!text/morekeys_i" />
+            <Key
+                latin:keySpec="j"
+                latin:keyHintLabel="0"
+                latin:additionalMoreKeys="0"
+                latin:moreKeys="!text/morekeys_j" />
+        </default>
+    </switch>
+</merge>

--- a/app/src/main/res/xml/rowkeys_alphabet2.xml
+++ b/app/src/main/res/xml/rowkeys_alphabet2.xml
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+/*
+**
+** Copyright 2012, The Android Open Source Project
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+-->
+
+<merge
+    xmlns:latin="http://schemas.android.com/apk/res-auto"
+>
+    <switch>
+        <case latin:showExtraChars="true">
+            <Key latin:keySpec="k"
+                latin:keyHintLabel="\@"
+                latin:additionalMoreKeys="\\@"
+                latin:moreKeys="!text/morekeys_k" />
+            <Key
+                latin:keySpec="l"
+                latin:keyHintLabel="#"
+                latin:additionalMoreKeys="#"
+                latin:moreKeys="!text/morekeys_l" />
+            <Key
+                latin:keySpec="m"
+                latin:keyHintLabel="$"
+                latin:additionalMoreKeys="$" />
+            <Key
+                latin:keySpec="n"
+                latin:keyHintLabel="%"
+                latin:additionalMoreKeys="%"
+                latin:moreKeys="!text/morekeys_n"  />
+            <Key
+                latin:keySpec="o"
+                latin:keyHintLabel="&amp;"
+                latin:additionalMoreKeys="&amp;"
+                latin:moreKeys="!text/morekeys_o"
+                />
+            <Key
+                latin:keySpec="p"
+                latin:keyHintLabel="-"
+                latin:additionalMoreKeys="-" />
+            <Key
+                latin:keySpec="!text/keyspec_q"
+                latin:keyHintLabel="+"
+                latin:additionalMoreKeys="+"
+                latin:moreKeys="!text/morekeys_q" />
+            <Key
+                latin:keySpec="r"
+                latin:keyHintLabel="("
+                latin:additionalMoreKeys="("
+                latin:moreKeys="!text/morekeys_r" />
+            <Key
+                latin:keySpec="s"
+                latin:keyHintLabel=")"
+                latin:additionalMoreKeys=")"
+                latin:moreKeys="!text/morekeys_s" />
+        </case>
+        <default>
+                <Key latin:keySpec="k"
+                latin:moreKeys="!text/morekeys_k" />
+            <Key
+                latin:keySpec="l"
+                latin:moreKeys="!text/morekeys_l" />
+            <Key
+                latin:keySpec="m" />
+            <Key
+                latin:keySpec="n"
+                latin:moreKeys="!text/morekeys_n"  />
+            <Key
+                latin:keySpec="o"
+                latin:moreKeys="!text/morekeys_o"
+                />
+            <Key
+                latin:keySpec="p" />
+            <Key
+                latin:keySpec="!text/keyspec_q"
+                latin:moreKeys="!text/morekeys_q" />
+            <Key
+                latin:keySpec="r"
+                latin:moreKeys="!text/morekeys_r" />
+            <Key
+                latin:keySpec="s"
+                latin:moreKeys="!text/morekeys_s" />
+        </default>
+    </switch>
+</merge>

--- a/app/src/main/res/xml/rowkeys_alphabet3.xml
+++ b/app/src/main/res/xml/rowkeys_alphabet3.xml
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+/*
+**
+** Copyright 2012, The Android Open Source Project
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+-->
+
+<merge
+    xmlns:latin="http://schemas.android.com/apk/res-auto"
+>
+    <switch>
+        <case latin:showExtraChars="true">
+            <Key
+                latin:keySpec="t"
+                latin:keyHintLabel="*"
+                latin:additionalMoreKeys="*"
+                latin:moreKeys="!text/morekeys_t" />
+            <Key
+                latin:keySpec="u"
+                latin:keyHintLabel="&quot;"
+                latin:additionalMoreKeys="&quot;"
+                latin:moreKeys="!text/morekeys_u" />
+            <Key
+                latin:keySpec="v"
+                latin:keyHintLabel="&apos;"
+                latin:additionalMoreKeys="&apos;"
+                latin:moreKeys="!text/morekeys_v" />
+            <Key
+                latin:keySpec="!text/keyspec_w"
+                latin:keyHintLabel=":"
+                latin:additionalMoreKeys=":"
+                latin:moreKeys="!text/morekeys_w" />
+            <Key
+                latin:keySpec="!text/keyspec_x"
+                latin:keyHintLabel=";"
+                latin:additionalMoreKeys=";"
+                latin:moreKeys="!text/morekeys_x"  />
+            <Key
+                latin:keySpec="!text/keyspec_y"
+                latin:keyHintLabel="!"
+                latin:additionalMoreKeys="!"
+                latin:moreKeys="!text/morekeys_y" />
+            <Key
+                latin:keySpec="z"
+                latin:keyHintLabel="\?"
+                latin:additionalMoreKeys="\\?"
+                latin:moreKeys="!text/morekeys_z" />
+        </case>
+        <default>
+             <Key
+                latin:keySpec="t"
+                latin:moreKeys="!text/morekeys_t" />
+            <Key
+                latin:keySpec="u"
+                latin:moreKeys="!text/morekeys_u" />
+            <Key
+                latin:keySpec="v"
+                latin:moreKeys="!text/morekeys_v" />
+            <Key
+                latin:keySpec="!text/keyspec_w"
+                latin:moreKeys="!text/morekeys_w" />
+            <Key
+                latin:keySpec="!text/keyspec_x"
+                latin:moreKeys="!text/morekeys_x"  />
+            <Key
+                latin:keySpec="!text/keyspec_y"
+                latin:moreKeys="!text/morekeys_y" />
+            <Key
+                latin:keySpec="z"
+                latin:moreKeys="!text/morekeys_z" />
+        </default>
+    </switch>
+</merge>

--- a/app/src/main/res/xml/rows_alphabet.xml
+++ b/app/src/main/res/xml/rows_alphabet.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+/*
+**
+** Copyright 2010, The Android Open Source Project
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+-->
+
+<merge xmlns:latin="http://schemas.android.com/apk/res-auto">
+    <Row
+        latin:keyWidth="10%p"
+    >
+        <include
+            latin:keyboardLayout="@xml/rowkeys_alphabet1" />
+    </Row>
+    <Row
+        latin:keyWidth="10%p"
+    >
+        <include
+            latin:keyboardLayout="@xml/rowkeys_alphabet2"
+            latin:keyXPos="5%p" />
+    </Row>
+    <Row
+        latin:keyWidth="10%p"
+    >
+        <Key
+            latin:keyStyle="shiftKeyStyle"
+            latin:keyWidth="15%p"
+            latin:visualInsetsRight="1%p" />
+        <include
+            latin:keyboardLayout="@xml/rowkeys_alphabet3" />
+        <Key
+            latin:keyStyle="deleteKeyStyle"
+            latin:keyWidth="fillRight"
+            latin:visualInsetsLeft="1%p" />
+    </Row>
+    <include
+        latin:keyboardLayout="@xml/row_alphabet4" />
+</merge>


### PR DESCRIPTION
First pull request ever so bear with me if I've made any mistakes here!

Just adding an Alphabet ordered keyboard because my dad has some trouble with qwerty, and I've yet to find an actually decent one on the market.

Everything seems to work alright in the emulator for typing. It seems like there might be an existing bug that prevents any alternative English keyboard from showing up on the settings page.

I named the layout "alphabet", but I understand that, that might create an unfortunate pun for other parts of the application where you refer to alphabet as the letters on the keyboard (as opposed to numbers and special characters). So if that needs to change for this to be acceptable, let me know!

Thanks!

![Screenshot_1561824176](https://user-images.githubusercontent.com/31391579/60386651-11f32580-9a66-11e9-83a6-1e71a53f1110.png)

![Screenshot_1561824361](https://user-images.githubusercontent.com/31391579/60386668-4cf55900-9a66-11e9-974b-d2e3a7666a79.png)

