### PR TITLE
Add small elevation effect for Android 5 and later

### DIFF
--- a/app/src/main/res/values-v21/themes-common.xml
+++ b/app/src/main/res/values-v21/themes-common.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <style name="InputView">
+        <item name="android:elevation">8dp</item>
+    </style>
+</resources>


### PR DESCRIPTION
Makes the keyboard look a bit "over" the content and not fused into it.

Screenshots: http://www.framecompare.com/screenshotcomparison/DWKDWNNX