### PR TITLE
Enable white navigation bar for bright keyboard colors

### DIFF
--- a/app/src/main/java/rkr/simplekeyboard/inputmethod/latin/LatinIME.java
+++ b/app/src/main/java/rkr/simplekeyboard/inputmethod/latin/LatinIME.java
@@ -1091,7 +1091,7 @@ public class LatinIME extends InputMethodService implements KeyboardActionListen
             }
             final View view = window.getDecorView();
             int flags = view.getSystemUiVisibility();
-            if (ResourceUtils.isBrightColor(keyboardColor)) {
+            if (mSettings.getCurrent().mUseMatchingNavbarColor && ResourceUtils.isBrightColor(keyboardColor)) {
                 flags |= View.SYSTEM_UI_FLAG_LIGHT_NAVIGATION_BAR;
                 window.setNavigationBarColor(Color.WHITE);
             } else {

--- a/app/src/main/java/rkr/simplekeyboard/inputmethod/latin/settings/Settings.java
+++ b/app/src/main/java/rkr/simplekeyboard/inputmethod/latin/settings/Settings.java
@@ -59,6 +59,7 @@ public final class Settings implements SharedPreferences.OnSharedPreferenceChang
     public static final String PREF_SHOW_NUMBER_ROW = "pref_show_number_row";
     public static final String PREF_SPACE_SWIPE = "pref_space_swipe";
     public static final String PREF_DELETE_SWIPE = "pref_delete_swipe";
+    public static final String PREF_MATCHING_NAVBAR_COLOR = "pref_matching_navbar_color";
 
     private static final float UNDEFINED_PREFERENCE_VALUE_FLOAT = -1.0f;
     private static final int UNDEFINED_PREFERENCE_VALUE_INT = -1;
@@ -277,5 +278,9 @@ public final class Settings implements SharedPreferences.OnSharedPreferenceChang
         // is NOKEYS and if it's not hidden (e.g. folded inside the device).
         return conf.keyboard != Configuration.KEYBOARD_NOKEYS
                 && conf.hardKeyboardHidden != Configuration.HARDKEYBOARDHIDDEN_YES;
+    }
+
+    public static boolean readUseMatchingNavbarColor(final SharedPreferences prefs) {
+        return prefs.getBoolean(PREF_MATCHING_NAVBAR_COLOR, false);
     }
 }

--- a/app/src/main/java/rkr/simplekeyboard/inputmethod/latin/settings/SettingsValues.java
+++ b/app/src/main/java/rkr/simplekeyboard/inputmethod/latin/settings/SettingsValues.java
@@ -53,6 +53,7 @@ public class SettingsValues {
     public final boolean mShowNumberRow;
     public final boolean mSpaceSwipeEnabled;
     public final boolean mDeleteSwipeEnabled;
+    public final boolean mUseMatchingNavbarColor;
 
     // From the input box
     public final InputAttributes mInputAttributes;
@@ -93,6 +94,7 @@ public class SettingsValues {
         mShowNumberRow = Settings.readShowNumberRow(prefs);
         mSpaceSwipeEnabled = Settings.readSpaceSwipeEnabled(prefs);
         mDeleteSwipeEnabled = Settings.readDeleteSwipeEnabled(prefs);
+        mUseMatchingNavbarColor = Settings.readUseMatchingNavbarColor(prefs);
     }
 
     public boolean isWordSeparator(final int code) {

--- a/app/src/main/java/rkr/simplekeyboard/inputmethod/latin/utils/ResourceUtils.java
+++ b/app/src/main/java/rkr/simplekeyboard/inputmethod/latin/utils/ResourceUtils.java
@@ -18,6 +18,7 @@ package rkr.simplekeyboard.inputmethod.latin.utils;
 
 import android.content.res.Resources;
 import android.content.res.TypedArray;
+import android.graphics.Color;
 import android.os.Build;
 import android.text.TextUtils;
 import android.util.DisplayMetrics;
@@ -273,5 +274,19 @@ public final class ResourceUtils {
 
     public static boolean isStringValue(final TypedValue v) {
         return v.type == TypedValue.TYPE_STRING;
+    }
+
+    public static boolean isBrightColor(int color) {
+        if (android.R.color.transparent == color) {
+            return true;
+        }
+        // See http://www.nbdtech.com/Blog/archive/2008/04/27/Calculating-the-Perceived-Brightness-of-a-Color.aspx
+        boolean bright = false;
+        int[] rgb = {Color.red(color), Color.green(color), Color.blue(color)};
+        int brightness = (int) Math.sqrt(rgb[0] * rgb[0] * .241 + rgb[1] * rgb[1] * .691 + rgb[2] * rgb[2] * .068);
+        if (brightness >= 210) {
+            bright = true;
+        }
+        return bright;
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -222,6 +222,7 @@ mobile devices. [CHAR LIMIT=25] -->
     <string name="show_number_row">Show separate number row</string>
     <string name="space_swipe">Space swipe cursor move</string>
     <string name="delete_swipe">Delete swipe</string>
+    <string name="matching_navbar_color">Use matching navigation bar color</string>
 
     <!-- Standard message to dismiss a dialog box -->
     <!-- Title of the button in a dialog box. The button takes the user to the keyboard settings. [CHAR LIMIT=15] -->

--- a/app/src/main/res/xml/prefs_screen_advanced.xml
+++ b/app/src/main/res/xml/prefs_screen_advanced.xml
@@ -43,6 +43,10 @@
         android:key="pref_keyboard_color"
         android:title="@string/keyboard_color" />
     <CheckBoxPreference
+        android:key="pref_matching_navbar_color"
+        android:title="@string/matching_navbar_color"
+        android:defaultValue="false" />
+    <CheckBoxPreference
         android:key="pref_hide_special_chars"
         android:title="@string/hide_special_chars"
         android:defaultValue="false" />


### PR DESCRIPTION
Also respects user defined keyboard background color.

Android 8 or newer required (SYSTEM_UI_FLAG_LIGHT_NAVIGATION_BAR).