### PR TITLE
reset the scale when reusing a key preview view

### DIFF
--- a/app/src/main/java/rkr/simplekeyboard/inputmethod/keyboard/internal/KeyPreviewChoreographer.java
+++ b/app/src/main/java/rkr/simplekeyboard/inputmethod/keyboard/internal/KeyPreviewChoreographer.java
@@ -51,10 +51,14 @@ public final class KeyPreviewChoreographer {
     public KeyPreviewView getKeyPreviewView(final Key key, final ViewGroup placerView) {
         KeyPreviewView keyPreviewView = mShowingKeyPreviewViews.remove(key);
         if (keyPreviewView != null) {
+            keyPreviewView.setScaleX(1);
+            keyPreviewView.setScaleY(1);
             return keyPreviewView;
         }
         keyPreviewView = mFreeKeyPreviewViews.poll();
         if (keyPreviewView != null) {
+            keyPreviewView.setScaleX(1);
+            keyPreviewView.setScaleY(1);
             return keyPreviewView;
         }
         final Context context = placerView.getContext();


### PR DESCRIPTION
There was a bug in the key preview size after a dismiss animator was used. This is most noticeable when using a key with a single more key because the more key keyboard is supposed to line up with the key preview. When a dismiss animator is used (eg: a normal key press when hardware accelerated) the animation doesn't get reset. The animation apparently results in the y dimension of the view to be scaled to 0.94 based on my testing. Since the view is reused, when another key is pressed that preview shows up as slightly shorter than expected. I reset the y scale when reusing the key preview view, and I did the same for the x scale for good measure, even though I didn't see it changing.