### PR TITLE
Recapitalization consistency fix

### DIFF
--- a/app/src/main/java/rkr/simplekeyboard/inputmethod/latin/common/StringUtils.java
+++ b/app/src/main/java/rkr/simplekeyboard/inputmethod/latin/common/StringUtils.java
@@ -192,7 +192,8 @@ public final class StringUtils {
         return true;
     }
 
-    public static boolean isIdenticalAfterCapitalizeEachWord(final String text) {
+    public static boolean isIdenticalAfterCapitalizeEachWord(final String text,
+                                                             final int[] sortedSeparators) {
         boolean needsCapsNext = true;
         final int len = text.length();
         for (int i = 0; i < len; i = text.offsetByCodePoints(i, 1)) {
@@ -203,15 +204,16 @@ public final class StringUtils {
                     return false;
                 }
             }
-            // We need a capital letter next if this is a whitespace.
-            needsCapsNext = Character.isWhitespace(codePoint);
+            // We need a capital letter next if this is a separator.
+            needsCapsNext = (Arrays.binarySearch(sortedSeparators, codePoint) >= 0);
         }
         return true;
     }
 
     // TODO: like capitalizeFirst*, this does not work perfectly for Dutch because of the IJ digraph
     // which should be capitalized together in *some* cases.
-    public static String capitalizeEachWord(final String text, final Locale locale) {
+    public static String capitalizeEachWord(final String text, final int[] sortedSeparators,
+                                            final Locale locale) {
         final StringBuilder builder = new StringBuilder();
         boolean needsCapsNext = true;
         final int len = text.length();
@@ -222,8 +224,8 @@ public final class StringUtils {
             } else {
                 builder.append(nextChar.toLowerCase(locale));
             }
-            // We need a capital letter next if this is a whitespace.
-            needsCapsNext = Character.isWhitespace(nextChar.codePointAt(0));
+            // We need a capital letter next if this is a separator.
+            needsCapsNext = (Arrays.binarySearch(sortedSeparators, nextChar.codePointAt(0)) >= 0);
         }
         return builder.toString();
     }

--- a/app/src/main/java/rkr/simplekeyboard/inputmethod/latin/inputlogic/InputLogic.java
+++ b/app/src/main/java/rkr/simplekeyboard/inputmethod/latin/inputlogic/InputLogic.java
@@ -400,7 +400,9 @@ public final class InputLogic {
             final CharSequence selectedText =
                     mConnection.getSelectedText(0 /* flags, 0 for no styles */);
             if (TextUtils.isEmpty(selectedText)) return; // Race condition with the input connection
-            mRecapitalizeStatus.start(selectionStart, selectionEnd, selectedText.toString(), settingsValues.mLocale);
+            mRecapitalizeStatus.start(selectionStart, selectionEnd, selectedText.toString(),
+                    settingsValues.mLocale,
+                    settingsValues.mSpacingAndPunctuations.mSortedWordSeparators);
             // We trim leading and trailing whitespace.
             mRecapitalizeStatus.trim();
         }

--- a/app/src/main/java/rkr/simplekeyboard/inputmethod/latin/utils/RecapitalizeStatus.java
+++ b/app/src/main/java/rkr/simplekeyboard/inputmethod/latin/utils/RecapitalizeStatus.java
@@ -37,12 +37,12 @@ public class RecapitalizeStatus {
         CAPS_MODE_ALL_UPPER
     };
 
-    private static final int getStringMode(final String string) {
+    private static final int getStringMode(final String string, final int[] sortedSeparators) {
         if (StringUtils.isIdenticalAfterUpcase(string)) {
             return CAPS_MODE_ALL_UPPER;
         } else if (StringUtils.isIdenticalAfterDowncase(string)) {
             return CAPS_MODE_ALL_LOWER;
-        } else if (StringUtils.isIdenticalAfterCapitalizeEachWord(string)) {
+        } else if (StringUtils.isIdenticalAfterCapitalizeEachWord(string, sortedSeparators)) {
             return CAPS_MODE_FIRST_WORD_UPPER;
         } else {
             return CAPS_MODE_ORIGINAL_MIXED_CASE;
@@ -71,17 +71,21 @@ public class RecapitalizeStatus {
     private int mRotationStyleCurrentIndex;
     private boolean mSkipOriginalMixedCaseMode;
     private Locale mLocale;
+    private int[] mSortedSeparators;
     private String mStringAfter;
     private boolean mIsStarted;
     private boolean mIsEnabled = true;
 
+    private static final int[] EMPTY_STORTED_SEPARATORS = {};
+
     public RecapitalizeStatus() {
         // By default, initialize with dummy values that won't match any real recapitalize.
-        start(-1, -1, "", Locale.getDefault());
+        start(-1, -1, "", Locale.getDefault(), EMPTY_STORTED_SEPARATORS);
         stop();
     }
 
-    public void start(final int cursorStart, final int cursorEnd, final String string, final Locale locale) {
+    public void start(final int cursorStart, final int cursorEnd, final String string,
+                      final Locale locale, final int[] sortedSeparators) {
         if (!mIsEnabled) {
             return;
         }
@@ -90,8 +94,9 @@ public class RecapitalizeStatus {
         mCursorStartAfter = cursorStart;
         mCursorEndAfter = cursorEnd;
         mStringAfter = string;
-        final int initialMode = getStringMode(mStringBefore);
+        final int initialMode = getStringMode(mStringBefore, sortedSeparators);
         mLocale = locale;
+        mSortedSeparators = sortedSeparators;
         if (CAPS_MODE_ORIGINAL_MIXED_CASE == initialMode) {
             mRotationStyleCurrentIndex = 0;
             mSkipOriginalMixedCaseMode = false;
@@ -155,7 +160,8 @@ public class RecapitalizeStatus {
                 mStringAfter = mStringBefore.toLowerCase(mLocale);
                 break;
             case CAPS_MODE_FIRST_WORD_UPPER:
-                mStringAfter = StringUtils.capitalizeEachWord(mStringBefore, mLocale);
+                mStringAfter = StringUtils.capitalizeEachWord(mStringBefore, mSortedSeparators,
+                        mLocale);
                 break;
             case CAPS_MODE_ALL_UPPER:
                 mStringAfter = mStringBefore.toUpperCase(mLocale);


### PR DESCRIPTION
One of the issues I was trying to address in #193 was to remove the inconsistency between recaptialization and auto-caps for capitalizing each word. For example my change made it so that when typing "s&p", without pressing the shift key, it will result in "S&P" to match what recapitalization does for capitalizing each word. This also made it match Gboard. I think you made the change in 5a2959c15fb51b63290a381c9cca54b947497e26 when you were initially pushing back against the change I was making, but my change was eventually accepted. Now recaptialization and auto-caps are inconsistent again because they flipped functionality. I recognize that this is actually the functionality that Gboard has, but I think that's a bug. This change is simply reverting the change made in 5a2959c15fb51b63290a381c9cca54b947497e26 to make recapitalization again capitalize letters after certain symbols when capitalizing each word.