### PR TITLE
Fix key hitboxes

### DIFF
--- a/app/src/main/java/rkr/simplekeyboard/inputmethod/keyboard/Key.java
+++ b/app/src/main/java/rkr/simplekeyboard/inputmethod/keyboard/Key.java
@@ -842,6 +842,18 @@ public class Key implements Comparable<Key> {
     }
 
     /**
+     * Detects if a point falls on this key.
+     * @param x the x-coordinate of the point
+     * @param y the y-coordinate of the point
+     * @return whether or not the point falls on the key. This generally includes all points
+     * between the key and the keyboard edge for keys attached to an edge and all points between
+     * the key and halfway to adjacent keys.
+     */
+    public boolean isOnKey(final int x, final int y) {
+        return mHitbox.contains(x, y);
+    }
+
+    /**
      * Returns the square of the distance to the nearest clickable edge of the key and the given
      * point.
      * @param x the x-coordinate of the point

--- a/app/src/main/java/rkr/simplekeyboard/inputmethod/keyboard/KeyDetector.java
+++ b/app/src/main/java/rkr/simplekeyboard/inputmethod/keyboard/KeyDetector.java
@@ -92,24 +92,11 @@ public class KeyDetector {
         final int touchX = getTouchX(x);
         final int touchY = getTouchY(y);
 
-        int minDistance = Integer.MAX_VALUE;
-        Key primaryKey = null;
         for (final Key key: mKeyboard.getNearestKeys(touchX, touchY)) {
-            // Compare the distance to the center of the keys as the primary tie-breaker for
-            // overlapping keys. This works better than just comparing how far the touch point is
-            // in the key because it helps prioritize smaller keys (harder to click) and it handles
-            // the extreme case of a the majority of a key overlapping another.
-            final int distance = key.squaredDistanceToHitboxEdge(touchX, touchY);
-            if (distance > minDistance) {
-                continue;
-            }
-            // To take care of hitbox overlaps, we compare key's code here too.
-            if (primaryKey == null || distance < minDistance
-                    || key.getCode() > primaryKey.getCode()) {
-                minDistance = distance;
-                primaryKey = key;
+            if (key.isOnKey(touchX, touchY)) {
+                return key;
             }
         }
-        return primaryKey;
+        return null;
     }
 }

--- a/app/src/main/java/rkr/simplekeyboard/inputmethod/keyboard/internal/KeyboardRow.java
+++ b/app/src/main/java/rkr/simplekeyboard/inputmethod/keyboard/internal/KeyboardRow.java
@@ -127,12 +127,14 @@ public final class KeyboardRow {
             // The top row should use the keyboard's top padding instead of the vertical gap
             mKeyTopPadding = params.mTopPadding;
         } else {
-            mKeyTopPadding = params.mVerticalGap / 2;
+            // All of the vertical gap will be used as bottom padding rather than split between the
+            // top and bottom because it is probably more likely for users to click below a key
+            mKeyTopPadding = 0;
         }
         final float baseRowHeight = ResourceUtils.getDimensionOrFraction(keyboardAttr,
                 R.styleable.Keyboard_rowHeight, params.mBaseHeight, params.mDefaultRowHeight);
         float keyHeight = baseRowHeight - params.mVerticalGap;
-        final float rowEndY = y + mKeyTopPadding + keyHeight + params.mVerticalGap / 2;
+        final float rowEndY = y + mKeyTopPadding + keyHeight + params.mVerticalGap;
         final float keyboardBottomEdge = params.mOccupiedHeight - params.mBottomPadding;
         if (rowEndY > keyboardBottomEdge - FLOAT_THRESHOLD) {
             // The bottom row's padding should go to the bottom of the keyboard (this might be
@@ -151,7 +153,7 @@ public final class KeyboardRow {
             }
             mKeyBottomPadding = Math.max(params.mOccupiedHeight - keyEndY, 0);
         } else {
-            mKeyBottomPadding = params.mVerticalGap / 2;
+            mKeyBottomPadding = params.mVerticalGap;
         }
         mRowHeight = mKeyTopPadding + keyHeight + mKeyBottomPadding;
         keyboardAttr.recycle();

--- a/app/src/main/res/values/config-common.xml
+++ b/app/src/main/res/values/config-common.xml
@@ -49,7 +49,7 @@
     <integer name="config_sliding_key_input_preview_body_ratio">100</integer>
     <integer name="config_sliding_key_input_preview_shadow_ratio">-1</integer>
     <dimen name="config_key_hysteresis_distance_for_sliding_modifier">8.0dp</dimen>
-    <dimen name="config_max_key_hitbox_padding">20.0dp</dimen>
+    <dimen name="config_max_key_hitbox_padding">70.0dp</dimen>
 
     <integer name="config_language_on_spacebar_final_alpha">128</integer>
     <dimen name="config_language_on_spacebar_horizontal_margin">1dp</dimen>


### PR DESCRIPTION
Based on our discussion in 17862f16c345bfc6b76401bdc344af565d807d77, I fixed key hitboxes by allocating all of the vertical gap to the key above it and increasing the key hitbox padding limit. Since the hitboxes should be fixed, I also reverted `detectHitKey` to directly check if the touch point is in the key's hitbox, and I removed extra handling for overlapping keys since that can't happen anymore.