### PR TITLE
Add extra characters and a separate number row to some keyboards

### DIFF
--- a/app/src/main/res/xml-sw600dp/keys_dvorak_123.xml
+++ b/app/src/main/res/xml-sw600dp/keys_dvorak_123.xml
@@ -22,38 +22,67 @@
     xmlns:latin="http://schemas.android.com/apk/res-auto"
 >
     <switch>
-        <case
-            latin:keyboardLayoutSetElement="alphabetManualShifted|alphabetShiftLocked|alphabetShiftLockShifted"
-        >
-            <Key
-                latin:keySpec="&quot;"
-                latin:keyHintLabel="1"
-                latin:additionalMoreKeys="1" />
-            <Key
-                latin:keySpec="&lt;"
-                latin:keyHintLabel="2"
-                latin:additionalMoreKeys="2" />
-            <Key
-                latin:keySpec="&gt;"
-                latin:keyHintLabel="3"
-                latin:additionalMoreKeys="3" />
+        <case latin:showNumberRow="true">
+            <switch>
+                <case
+                    latin:keyboardLayoutSetElement="alphabetManualShifted|alphabetShiftLocked|alphabetShiftLockShifted"
+                    >
+                    <Key
+                        latin:keySpec="&quot;" />
+                    <Key
+                        latin:keySpec="&lt;" />
+                    <Key
+                        latin:keySpec="&gt;" />
+                </case>
+                <default>
+                    <Key
+                        latin:keySpec="\'"
+                        latin:moreKeys="!,&quot;" />
+                    <Key
+                        latin:keySpec=","
+                        latin:moreKeys="\?,&lt;" />
+                    <Key
+                        latin:keySpec="."
+                        latin:moreKeys="&gt;" />
+                </default>
+            </switch>
         </case>
         <default>
-            <Key
-                latin:keySpec="\'"
-                latin:keyHintLabel="1"
-                latin:additionalMoreKeys="1"
-                latin:moreKeys="!,&quot;" />
-            <Key
-                latin:keySpec=","
-                latin:keyHintLabel="2"
-                latin:additionalMoreKeys="2"
-                latin:moreKeys="\?,&lt;" />
-            <Key
-                latin:keySpec="."
-                latin:keyHintLabel="3"
-                latin:additionalMoreKeys="3"
-                latin:moreKeys="&gt;" />
+            <switch>
+                <case
+                    latin:keyboardLayoutSetElement="alphabetManualShifted|alphabetShiftLocked|alphabetShiftLockShifted"
+                >
+                    <Key
+                        latin:keySpec="&quot;"
+                        latin:keyHintLabel="1"
+                        latin:additionalMoreKeys="1" />
+                    <Key
+                        latin:keySpec="&lt;"
+                        latin:keyHintLabel="2"
+                        latin:additionalMoreKeys="2" />
+                    <Key
+                        latin:keySpec="&gt;"
+                        latin:keyHintLabel="3"
+                        latin:additionalMoreKeys="3" />
+                </case>
+                <default>
+                    <Key
+                        latin:keySpec="\'"
+                        latin:keyHintLabel="1"
+                        latin:additionalMoreKeys="1"
+                        latin:moreKeys="!,&quot;" />
+                    <Key
+                        latin:keySpec=","
+                        latin:keyHintLabel="2"
+                        latin:additionalMoreKeys="2"
+                        latin:moreKeys="\?,&lt;" />
+                    <Key
+                        latin:keySpec="."
+                        latin:keyHintLabel="3"
+                        latin:additionalMoreKeys="3"
+                        latin:moreKeys="&gt;" />
+                </default>
+            </switch>
         </default>
     </switch>
 </merge>

--- a/app/src/main/res/xml-sw600dp/rowkeys_dvorak3.xml
+++ b/app/src/main/res/xml-sw600dp/rowkeys_dvorak3.xml
@@ -21,27 +21,70 @@
 <merge
     xmlns:latin="http://schemas.android.com/apk/res-auto"
 >
-    <Key
-        latin:keySpec="q" />
-    <Key
-        latin:keySpec="j"
-        latin:moreKeys="!text/morekeys_j" />
-    <Key
-        latin:keySpec="k"
-        latin:moreKeys="!text/morekeys_k" />
-    <Key
-        latin:keySpec="x" />
-    <Key
-        latin:keySpec="b" />
-    <Key
-        latin:keySpec="m" />
-    <Key
-        latin:keySpec="w"
-        latin:moreKeys="!text/morekeys_w" />
-    <Key
-        latin:keySpec="v"
-        latin:moreKeys="!text/morekeys_v" />
-    <Key
-        latin:keySpec="z"
-        latin:moreKeys="!text/morekeys_z" />
+    <switch>
+        <case latin:showExtraChars="true">
+            <Key
+                latin:keySpec="q" />
+            <Key
+                latin:keySpec="j"
+                latin:moreKeys="!text/morekeys_j"
+                latin:keyHintLabel="*"
+                latin:additionalMoreKeys="*" />
+            <Key
+                latin:keySpec="k"
+                latin:moreKeys="!text/morekeys_k"
+                latin:keyHintLabel="&quot;"
+                latin:additionalMoreKeys="&quot;" />
+            <Key
+                latin:keySpec="x"
+                latin:keyHintLabel="&apos;"
+                latin:additionalMoreKeys="&apos;" />
+            <Key
+                latin:keySpec="b"
+                latin:keyHintLabel=":"
+                latin:additionalMoreKeys=":" />
+            <Key
+                latin:keySpec="m"
+                latin:keyHintLabel=";"
+                latin:additionalMoreKeys=";" />
+            <Key
+                latin:keySpec="w"
+                latin:moreKeys="!text/morekeys_w"
+                latin:keyHintLabel="!"
+                latin:additionalMoreKeys="!" />
+            <Key
+                latin:keySpec="v"
+                latin:moreKeys="!text/morekeys_v"
+                latin:keyHintLabel="\?"
+                latin:additionalMoreKeys="\?" />
+            <Key
+                latin:keySpec="z"
+                latin:moreKeys="!text/morekeys_z" />
+        </case>
+        <default>
+            <Key
+                latin:keySpec="q" />
+            <Key
+                latin:keySpec="j"
+                latin:moreKeys="!text/morekeys_j" />
+            <Key
+                latin:keySpec="k"
+                latin:moreKeys="!text/morekeys_k" />
+            <Key
+                latin:keySpec="x" />
+            <Key
+                latin:keySpec="b" />
+            <Key
+                latin:keySpec="m" />
+            <Key
+                latin:keySpec="w"
+                latin:moreKeys="!text/morekeys_w" />
+            <Key
+                latin:keySpec="v"
+                latin:moreKeys="!text/morekeys_v" />
+            <Key
+                latin:keySpec="z"
+                latin:moreKeys="!text/morekeys_z" />
+        </default>
+    </switch>
 </merge>

--- a/app/src/main/res/xml/kbd_dvorak.xml
+++ b/app/src/main/res/xml/kbd_dvorak.xml
@@ -21,6 +21,16 @@
 <Keyboard
     xmlns:latin="http://schemas.android.com/apk/res-auto"
 >
-    <include
-        latin:keyboardLayout="@xml/rows_dvorak" />
+    <switch>
+        <case latin:showNumberRow="true">
+            <include latin:keyboardLayout="@xml/rowkeys_qwerty0" />
+
+            <include
+                latin:keyboardLayout="@xml/rows_dvorak"
+                latin:rowHeight="21.25%p"/>
+        </case>
+        <default>
+            <include latin:keyboardLayout="@xml/rows_dvorak" />
+        </default>
+    </switch>
 </Keyboard>

--- a/app/src/main/res/xml/keys_dvorak_123.xml
+++ b/app/src/main/res/xml/keys_dvorak_123.xml
@@ -22,62 +22,111 @@
     xmlns:latin="http://schemas.android.com/apk/res-auto"
 >
     <switch>
-        <case
-            latin:keyboardLayoutSetElement="alphabetManualShifted|alphabetShiftLocked|alphabetShiftLockShifted"
-        >
-            <Key
-                latin:keySpec="&quot;"
-                latin:keyHintLabel="1"
-                latin:additionalMoreKeys="1" />
-        </case>
-        <case
-            latin:mode="url"
-        >
-            <Key
-                latin:keySpec="/"
-                latin:keyHintLabel="1"
-                latin:additionalMoreKeys="1" />
-        </case>
-        <case
-            latin:mode="email"
-        >
-            <Key
-                latin:keySpec="\@"
-                latin:keyHintLabel="1"
-                latin:additionalMoreKeys="1" />
+        <case latin:showNumberRow="true">
+            <switch>
+                <case
+                    latin:keyboardLayoutSetElement="alphabetManualShifted|alphabetShiftLocked|alphabetShiftLockShifted"
+                    >
+                    <Key
+                        latin:keySpec="&quot;" />
+                </case>
+                <case
+                    latin:mode="url"
+                    >
+                    <Key
+                        latin:keySpec="/" />
+                </case>
+                <case
+                    latin:mode="email"
+                    >
+                    <Key
+                        latin:keySpec="\@" />
+                </case>
+                <default>
+                    <Key
+                        latin:keySpec="\'"
+                        latin:moreKeys="!,&quot;" />
+                </default>
+            </switch>
+            <switch>
+                <case
+                    latin:keyboardLayoutSetElement="alphabetManualShifted|alphabetShiftLocked|alphabetShiftLockShifted"
+                    >
+                    <Key
+                        latin:keySpec="&lt;" />
+                    <Key
+                        latin:keySpec="&gt;" />
+                </case>
+                <default>
+                    <Key
+                        latin:keySpec=","
+                        latin:moreKeys="\?,&lt;" />
+                    <Key
+                        latin:keySpec="."
+                        latin:moreKeys="&gt;" />
+                </default>
+            </switch>
         </case>
         <default>
-            <Key
-                latin:keySpec="\'"
-                latin:keyHintLabel="1"
-                latin:additionalMoreKeys="1"
-                latin:moreKeys="!,&quot;" />
-        </default>
-    </switch>
-    <switch>
-        <case
-            latin:keyboardLayoutSetElement="alphabetManualShifted|alphabetShiftLocked|alphabetShiftLockShifted"
-        >
-            <Key
-                latin:keySpec="&lt;"
-                latin:keyHintLabel="2"
-                latin:additionalMoreKeys="2" />
-            <Key
-                latin:keySpec="&gt;"
-                latin:keyHintLabel="3"
-                latin:additionalMoreKeys="3" />
-        </case>
-        <default>
-            <Key
-                latin:keySpec=","
-                latin:keyHintLabel="2"
-                latin:additionalMoreKeys="2"
-                latin:moreKeys="\?,&lt;" />
-            <Key
-                latin:keySpec="."
-                latin:keyHintLabel="3"
-                latin:additionalMoreKeys="3"
-                latin:moreKeys="&gt;" />
+            <switch>
+                <case
+                    latin:keyboardLayoutSetElement="alphabetManualShifted|alphabetShiftLocked|alphabetShiftLockShifted"
+                >
+                    <Key
+                        latin:keySpec="&quot;"
+                        latin:keyHintLabel="1"
+                        latin:additionalMoreKeys="1" />
+                </case>
+                <case
+                    latin:mode="url"
+                >
+                    <Key
+                        latin:keySpec="/"
+                        latin:keyHintLabel="1"
+                        latin:additionalMoreKeys="1" />
+                </case>
+                <case
+                    latin:mode="email"
+                >
+                    <Key
+                        latin:keySpec="\@"
+                        latin:keyHintLabel="1"
+                        latin:additionalMoreKeys="1" />
+                </case>
+                <default>
+                    <Key
+                        latin:keySpec="\'"
+                        latin:keyHintLabel="1"
+                        latin:additionalMoreKeys="1"
+                        latin:moreKeys="!,&quot;" />
+                </default>
+            </switch>
+            <switch>
+                <case
+                    latin:keyboardLayoutSetElement="alphabetManualShifted|alphabetShiftLocked|alphabetShiftLockShifted"
+                >
+                    <Key
+                        latin:keySpec="&lt;"
+                        latin:keyHintLabel="2"
+                        latin:additionalMoreKeys="2" />
+                    <Key
+                        latin:keySpec="&gt;"
+                        latin:keyHintLabel="3"
+                        latin:additionalMoreKeys="3" />
+                </case>
+                <default>
+                    <Key
+                        latin:keySpec=","
+                        latin:keyHintLabel="2"
+                        latin:additionalMoreKeys="2"
+                        latin:moreKeys="\?,&lt;" />
+                    <Key
+                        latin:keySpec="."
+                        latin:keyHintLabel="3"
+                        latin:additionalMoreKeys="3"
+                        latin:moreKeys="&gt;" />
+                </default>
+            </switch>
         </default>
     </switch>
 </merge>

--- a/app/src/main/res/xml/rowkeys_azerty2.xml
+++ b/app/src/main/res/xml/rowkeys_azerty2.xml
@@ -21,31 +21,84 @@
 <merge
     xmlns:latin="http://schemas.android.com/apk/res-auto"
 >
-    <Key
-        latin:keySpec="q" />
-    <Key
-        latin:keySpec="s"
-        latin:moreKeys="!text/morekeys_s" />
-    <Key
-        latin:keySpec="d"
-        latin:moreKeys="!text/morekeys_d" />
-    <Key
-        latin:keySpec="f" />
-    <Key
-        latin:keySpec="g"
-        latin:moreKeys="!text/morekeys_g" />
-    <Key
-        latin:keySpec="h"
-        latin:moreKeys="!text/morekeys_h" />
-    <Key
-        latin:keySpec="j"
-        latin:moreKeys="!text/morekeys_j" />
-    <Key
-        latin:keySpec="k"
-        latin:moreKeys="!text/morekeys_k" />
-    <Key
-        latin:keySpec="l"
-        latin:moreKeys="!text/morekeys_l" />
-    <Key
-        latin:keySpec="m" />
+    <switch>
+        <case latin:showExtraChars="true">
+            <Key
+                latin:keySpec="q"
+                latin:keyHintLabel="\@"
+                latin:additionalMoreKeys="\@" />
+            <Key
+                latin:keySpec="s"
+                latin:moreKeys="!text/morekeys_s"
+                latin:keyHintLabel="#"
+                latin:additionalMoreKeys="#" />
+            <Key
+                latin:keySpec="d"
+                latin:moreKeys="!text/morekeys_d"
+                latin:keyHintLabel="$"
+                latin:additionalMoreKeys="$" />
+            <Key
+                latin:keySpec="f"
+                latin:keyHintLabel="%"
+                latin:additionalMoreKeys="%" />
+            <Key
+                latin:keySpec="g"
+                latin:moreKeys="!text/morekeys_g"
+                latin:keyHintLabel="&amp;"
+                latin:additionalMoreKeys="&amp;" />
+            <Key
+                latin:keySpec="h"
+                latin:moreKeys="!text/morekeys_h"
+                latin:keyHintLabel="-"
+                latin:additionalMoreKeys="-" />
+            <Key
+                latin:keySpec="j"
+                latin:moreKeys="!text/morekeys_j"
+                latin:keyHintLabel="+"
+                latin:additionalMoreKeys="+" />
+            <Key
+                latin:keySpec="k"
+                latin:moreKeys="!text/morekeys_k"
+                latin:keyHintLabel="("
+                latin:additionalMoreKeys="(" />
+            <Key
+                latin:keySpec="l"
+                latin:moreKeys="!text/morekeys_l"
+                latin:keyHintLabel=")"
+                latin:additionalMoreKeys=")" />
+            <Key
+                latin:keySpec="m"
+                latin:keyHintLabel="/"
+                latin:additionalMoreKeys="/" />
+        </case>
+        <default>
+            <Key
+                latin:keySpec="q" />
+            <Key
+                latin:keySpec="s"
+                latin:moreKeys="!text/morekeys_s" />
+            <Key
+                latin:keySpec="d"
+                latin:moreKeys="!text/morekeys_d" />
+            <Key
+                latin:keySpec="f" />
+            <Key
+                latin:keySpec="g"
+                latin:moreKeys="!text/morekeys_g" />
+            <Key
+                latin:keySpec="h"
+                latin:moreKeys="!text/morekeys_h" />
+            <Key
+                latin:keySpec="j"
+                latin:moreKeys="!text/morekeys_j" />
+            <Key
+                latin:keySpec="k"
+                latin:moreKeys="!text/morekeys_k" />
+            <Key
+                latin:keySpec="l"
+                latin:moreKeys="!text/morekeys_l" />
+            <Key
+                latin:keySpec="m" />
+        </default>
+    </switch>
 </merge>

--- a/app/src/main/res/xml/rowkeys_azerty3.xml
+++ b/app/src/main/res/xml/rowkeys_azerty3.xml
@@ -21,22 +21,56 @@
 <merge
     xmlns:latin="http://schemas.android.com/apk/res-auto"
 >
-    <Key
-        latin:keySpec="w"
-        latin:moreKeys="!text/morekeys_w" />
-    <Key
-        latin:keySpec="x" />
-    <Key
-        latin:keySpec="c"
-        latin:moreKeys="!text/morekeys_c" />
-    <Key
-        latin:keySpec="v"
-        latin:moreKeys="!text/morekeys_v" />
-    <Key
-        latin:keySpec="b" />
-    <Key
-        latin:keySpec="n"
-        latin:moreKeys="!text/morekeys_n" />
+    <switch>
+        <case latin:showExtraChars="true">
+            <Key
+                latin:keySpec="w"
+                latin:moreKeys="!text/morekeys_w"
+                latin:keyHintLabel="*"
+                latin:additionalMoreKeys="*" />
+            <Key
+                latin:keySpec="x"
+                latin:keyHintLabel="&quot;"
+                latin:additionalMoreKeys="&quot;" />
+            <Key
+                latin:keySpec="c"
+                latin:moreKeys="!text/morekeys_c"
+                latin:keyHintLabel="&apos;"
+                latin:additionalMoreKeys="&apos;" />
+            <Key
+                latin:keySpec="v"
+                latin:moreKeys="!text/morekeys_v"
+                latin:keyHintLabel=":"
+                latin:additionalMoreKeys=":" />
+            <Key
+                latin:keySpec="b"
+                latin:keyHintLabel=";"
+                latin:additionalMoreKeys=";" />
+            <Key
+                latin:keySpec="n"
+                latin:moreKeys="!text/morekeys_n"
+                latin:keyHintLabel="!"
+                latin:additionalMoreKeys="!" />
+        </case>
+        <default>
+            <Key
+                latin:keySpec="w"
+                latin:moreKeys="!text/morekeys_w" />
+            <Key
+                latin:keySpec="x" />
+            <Key
+                latin:keySpec="c"
+                latin:moreKeys="!text/morekeys_c" />
+            <Key
+                latin:keySpec="v"
+                latin:moreKeys="!text/morekeys_v" />
+            <Key
+                latin:keySpec="b" />
+            <Key
+                latin:keySpec="n"
+                latin:moreKeys="!text/morekeys_n" />
+        </default>
+    </switch>
     <switch>
         <case
             latin:keyboardLayoutSetElement="alphabetManualShifted|alphabetShiftLockShifted"

--- a/app/src/main/res/xml/rowkeys_colemak1.xml
+++ b/app/src/main/res/xml/rowkeys_colemak1.xml
@@ -54,11 +54,15 @@
                     <Key
                         latin:keySpec=":" />
                 </case>
-                <default>
+                <case latin:showExtraChars="true">
                     <Key
                         latin:keySpec=";"
                         latin:keyHintLabel=":"
                         latin:additionalMoreKeys=":" />
+                </case>
+                <default>
+                    <Key
+                        latin:keySpec=";" />
                 </default>
             </switch>
         </case>
@@ -114,12 +118,18 @@
                         latin:keyHintLabel="0"
                         latin:additionalMoreKeys="0" />
                 </case>
-                <default>
+                <case latin:showExtraChars="true">
                     <Key
                         latin:keySpec=";"
                         latin:keyHintLabel="0"
                         latin:additionalMoreKeys="0"
                         latin:moreKeys=":" />
+                </case>
+                <default>
+                    <Key
+                        latin:keySpec=";"
+                        latin:keyHintLabel="0"
+                        latin:additionalMoreKeys="0" />
                 </default>
             </switch>
         </default>

--- a/app/src/main/res/xml/rowkeys_colemak2.xml
+++ b/app/src/main/res/xml/rowkeys_colemak2.xml
@@ -21,34 +21,90 @@
 <merge
     xmlns:latin="http://schemas.android.com/apk/res-auto"
 >
-    <Key
-        latin:keySpec="a"
-        latin:moreKeys="!text/morekeys_a" />
-    <Key
-        latin:keySpec="r"
-        latin:moreKeys="!text/morekeys_r" />
-    <Key
-        latin:keySpec="s"
-        latin:moreKeys="!text/morekeys_s" />
-    <Key
-        latin:keySpec="t"
-        latin:moreKeys="!text/morekeys_t" />
-    <Key
-        latin:keySpec="d"
-        latin:moreKeys="!text/morekeys_d" />
-    <Key
-        latin:keySpec="h"
-        latin:moreKeys="!text/morekeys_h" />
-    <Key
-        latin:keySpec="n"
-        latin:moreKeys="!text/morekeys_n" />
-    <Key
-        latin:keySpec="e"
-        latin:moreKeys="!text/morekeys_e" />
-    <Key
-        latin:keySpec="i"
-        latin:moreKeys="!text/morekeys_i" />
-    <Key
-        latin:keySpec="o"
-        latin:moreKeys="!text/morekeys_o" />
+    <switch>
+        <case latin:showExtraChars="true">
+            <Key
+                latin:keySpec="a"
+                latin:moreKeys="!text/morekeys_a"
+                latin:keyHintLabel="\@"
+                latin:additionalMoreKeys="\@" />
+            <Key
+                latin:keySpec="r"
+                latin:moreKeys="!text/morekeys_r"
+                latin:keyHintLabel="#"
+                latin:additionalMoreKeys="#" />
+            <Key
+                latin:keySpec="s"
+                latin:moreKeys="!text/morekeys_s"
+                latin:keyHintLabel="$"
+                latin:additionalMoreKeys="$" />
+            <Key
+                latin:keySpec="t"
+                latin:moreKeys="!text/morekeys_t"
+                latin:keyHintLabel="%"
+                latin:additionalMoreKeys="%" />
+            <Key
+                latin:keySpec="d"
+                latin:moreKeys="!text/morekeys_d"
+                latin:keyHintLabel="&amp;"
+                latin:additionalMoreKeys="&amp;" />
+            <Key
+                latin:keySpec="h"
+                latin:moreKeys="!text/morekeys_h"
+                latin:keyHintLabel="-"
+                latin:additionalMoreKeys="-" />
+            <Key
+                latin:keySpec="n"
+                latin:moreKeys="!text/morekeys_n"
+                latin:keyHintLabel="+"
+                latin:additionalMoreKeys="+" />
+            <Key
+                latin:keySpec="e"
+                latin:moreKeys="!text/morekeys_e"
+                latin:keyHintLabel="("
+                latin:additionalMoreKeys="(" />
+            <Key
+                latin:keySpec="i"
+                latin:moreKeys="!text/morekeys_i"
+                latin:keyHintLabel=")"
+                latin:additionalMoreKeys=")" />
+            <Key
+                latin:keySpec="o"
+                latin:moreKeys="!text/morekeys_o"
+                latin:keyHintLabel="/"
+                latin:additionalMoreKeys="/" />
+        </case>
+        <default>
+            <Key
+                latin:keySpec="a"
+                latin:moreKeys="!text/morekeys_a" />
+            <Key
+                latin:keySpec="r"
+                latin:moreKeys="!text/morekeys_r" />
+            <Key
+                latin:keySpec="s"
+                latin:moreKeys="!text/morekeys_s" />
+            <Key
+                latin:keySpec="t"
+                latin:moreKeys="!text/morekeys_t" />
+            <Key
+                latin:keySpec="d"
+                latin:moreKeys="!text/morekeys_d" />
+            <Key
+                latin:keySpec="h"
+                latin:moreKeys="!text/morekeys_h" />
+            <Key
+                latin:keySpec="n"
+                latin:moreKeys="!text/morekeys_n" />
+            <Key
+                latin:keySpec="e"
+                latin:moreKeys="!text/morekeys_e" />
+            <Key
+                latin:keySpec="i"
+                latin:moreKeys="!text/morekeys_i" />
+            <Key
+                latin:keySpec="o"
+                latin:moreKeys="!text/morekeys_o" />
+        </default>
+    </switch>
 </merge>

--- a/app/src/main/res/xml/rowkeys_colemak3.xml
+++ b/app/src/main/res/xml/rowkeys_colemak3.xml
@@ -21,22 +21,60 @@
 <merge
     xmlns:latin="http://schemas.android.com/apk/res-auto"
 >
-    <Key
-        latin:keySpec="z"
-        latin:moreKeys="!text/morekeys_z" />
-    <Key
-        latin:keySpec="x" />
-    <Key
-        latin:keySpec="c"
-        latin:moreKeys="!text/morekeys_c" />
-    <Key
-        latin:keySpec="v"
-        latin:moreKeys="!text/morekeys_v" />
-    <Key
-        latin:keySpec="b" />
-    <Key
-        latin:keySpec="k"
-        latin:moreKeys="!text/morekeys_k" />
-    <Key
-        latin:keySpec="m" />
+    <switch>
+        <case latin:showExtraChars="true">
+            <Key
+                latin:keySpec="z"
+                latin:moreKeys="!text/morekeys_z"
+                latin:keyHintLabel="*"
+                latin:additionalMoreKeys="*" />
+            <Key
+                latin:keySpec="x"
+                latin:keyHintLabel="&quot;"
+                latin:additionalMoreKeys="&quot;" />
+            <Key
+                latin:keySpec="c"
+                latin:moreKeys="!text/morekeys_c"
+                latin:keyHintLabel="&apos;"
+                latin:additionalMoreKeys="&apos;" />
+            <Key
+                latin:keySpec="v"
+                latin:moreKeys="!text/morekeys_v"
+                latin:keyHintLabel=":"
+                latin:additionalMoreKeys=":" />
+            <Key
+                latin:keySpec="b"
+                latin:keyHintLabel=";"
+                latin:additionalMoreKeys=";" />
+            <Key
+                latin:keySpec="k"
+                latin:moreKeys="!text/morekeys_k"
+                latin:keyHintLabel="!"
+                latin:additionalMoreKeys="!" />
+            <Key
+                latin:keySpec="m"
+                latin:keyHintLabel="\?"
+                latin:additionalMoreKeys="\?" />
+        </case>
+        <default>
+            <Key
+                latin:keySpec="z"
+                latin:moreKeys="!text/morekeys_z" />
+            <Key
+                latin:keySpec="x" />
+            <Key
+                latin:keySpec="c"
+                latin:moreKeys="!text/morekeys_c" />
+            <Key
+                latin:keySpec="v"
+                latin:moreKeys="!text/morekeys_v" />
+            <Key
+                latin:keySpec="b" />
+            <Key
+                latin:keySpec="k"
+                latin:moreKeys="!text/morekeys_k" />
+            <Key
+                latin:keySpec="m" />
+        </default>
+    </switch>
 </merge>

--- a/app/src/main/res/xml/rowkeys_dvorak1.xml
+++ b/app/src/main/res/xml/rowkeys_dvorak1.xml
@@ -23,37 +23,62 @@
 >
     <include
         latin:keyboardLayout="@xml/keys_dvorak_123" />
-    <Key
-        latin:keySpec="p"
-        latin:keyHintLabel="4"
-        latin:additionalMoreKeys="4" />
-    <Key
-        latin:keySpec="y"
-        latin:keyHintLabel="5"
-        latin:additionalMoreKeys="5"
-        latin:moreKeys="!text/morekeys_y" />
-    <Key
-        latin:keySpec="f"
-        latin:keyHintLabel="6"
-        latin:additionalMoreKeys="6" />
-    <Key
-        latin:keySpec="g"
-        latin:keyHintLabel="7"
-        latin:additionalMoreKeys="7"
-        latin:moreKeys="!text/morekeys_g" />
-    <Key
-        latin:keySpec="c"
-        latin:keyHintLabel="8"
-        latin:additionalMoreKeys="8"
-        latin:moreKeys="!text/morekeys_c" />
-    <Key
-        latin:keySpec="r"
-        latin:keyHintLabel="9"
-        latin:additionalMoreKeys="9"
-        latin:moreKeys="!text/morekeys_r" />
-    <Key
-        latin:keySpec="l"
-        latin:keyHintLabel="0"
-        latin:additionalMoreKeys="0"
-        latin:moreKeys="!text/morekeys_l" />
+    <switch>
+        <case latin:showNumberRow="true">
+            <Key
+                latin:keySpec="p" />
+            <Key
+                latin:keySpec="y"
+                latin:moreKeys="!text/morekeys_y" />
+            <Key
+                latin:keySpec="f" />
+            <Key
+                latin:keySpec="g"
+                latin:moreKeys="!text/morekeys_g" />
+            <Key
+                latin:keySpec="c"
+                latin:moreKeys="!text/morekeys_c" />
+            <Key
+                latin:keySpec="r"
+                latin:moreKeys="!text/morekeys_r" />
+            <Key
+                latin:keySpec="l"
+                latin:moreKeys="!text/morekeys_l" />
+        </case>
+        <default>
+            <Key
+                latin:keySpec="p"
+                latin:keyHintLabel="4"
+                latin:additionalMoreKeys="4" />
+            <Key
+                latin:keySpec="y"
+                latin:keyHintLabel="5"
+                latin:additionalMoreKeys="5"
+                latin:moreKeys="!text/morekeys_y" />
+            <Key
+                latin:keySpec="f"
+                latin:keyHintLabel="6"
+                latin:additionalMoreKeys="6" />
+            <Key
+                latin:keySpec="g"
+                latin:keyHintLabel="7"
+                latin:additionalMoreKeys="7"
+                latin:moreKeys="!text/morekeys_g" />
+            <Key
+                latin:keySpec="c"
+                latin:keyHintLabel="8"
+                latin:additionalMoreKeys="8"
+                latin:moreKeys="!text/morekeys_c" />
+            <Key
+                latin:keySpec="r"
+                latin:keyHintLabel="9"
+                latin:additionalMoreKeys="9"
+                latin:moreKeys="!text/morekeys_r" />
+            <Key
+                latin:keySpec="l"
+                latin:keyHintLabel="0"
+                latin:additionalMoreKeys="0"
+                latin:moreKeys="!text/morekeys_l" />
+        </default>
+    </switch>
 </merge>

--- a/app/src/main/res/xml/rowkeys_dvorak2.xml
+++ b/app/src/main/res/xml/rowkeys_dvorak2.xml
@@ -21,34 +21,90 @@
 <merge
     xmlns:latin="http://schemas.android.com/apk/res-auto"
 >
-    <Key
-        latin:keySpec="a"
-        latin:moreKeys="!text/morekeys_a" />
-    <Key
-        latin:keySpec="o"
-        latin:moreKeys="!text/morekeys_o" />
-    <Key
-        latin:keySpec="e"
-        latin:moreKeys="!text/morekeys_e" />
-    <Key
-        latin:keySpec="u"
-        latin:moreKeys="!text/morekeys_u" />
-    <Key
-        latin:keySpec="i"
-        latin:moreKeys="!text/morekeys_i" />
-    <Key
-        latin:keySpec="d"
-        latin:moreKeys="!text/morekeys_d" />
-    <Key
-        latin:keySpec="h"
-        latin:moreKeys="!text/morekeys_h" />
-    <Key
-        latin:keySpec="t"
-        latin:moreKeys="!text/morekeys_t" />
-    <Key
-        latin:keySpec="n"
-        latin:moreKeys="!text/morekeys_n" />
-    <Key
-        latin:keySpec="s"
-        latin:moreKeys="!text/morekeys_s" />
+    <switch>
+        <case latin:showExtraChars="true">
+            <Key
+                latin:keySpec="a"
+                latin:moreKeys="!text/morekeys_a"
+                latin:keyHintLabel="\@"
+                latin:additionalMoreKeys="\@" />
+            <Key
+                latin:keySpec="o"
+                latin:moreKeys="!text/morekeys_o"
+                latin:keyHintLabel="#"
+                latin:additionalMoreKeys="#"  />
+            <Key
+                latin:keySpec="e"
+                latin:moreKeys="!text/morekeys_e"
+                latin:keyHintLabel="$"
+                latin:additionalMoreKeys="$" />
+            <Key
+                latin:keySpec="u"
+                latin:moreKeys="!text/morekeys_u"
+                latin:keyHintLabel="%"
+                latin:additionalMoreKeys="%" />
+            <Key
+                latin:keySpec="i"
+                latin:moreKeys="!text/morekeys_i"
+                latin:keyHintLabel="&amp;"
+                latin:additionalMoreKeys="&amp;" />
+            <Key
+                latin:keySpec="d"
+                latin:moreKeys="!text/morekeys_d"
+                latin:keyHintLabel="-"
+                latin:additionalMoreKeys="-" />
+            <Key
+                latin:keySpec="h"
+                latin:moreKeys="!text/morekeys_h"
+                latin:keyHintLabel="+"
+                latin:additionalMoreKeys="+" />
+            <Key
+                latin:keySpec="t"
+                latin:moreKeys="!text/morekeys_t"
+                latin:keyHintLabel="("
+                latin:additionalMoreKeys="(" />
+            <Key
+                latin:keySpec="n"
+                latin:moreKeys="!text/morekeys_n"
+                latin:keyHintLabel=")"
+                latin:additionalMoreKeys=")" />
+            <Key
+                latin:keySpec="s"
+                latin:moreKeys="!text/morekeys_s"
+                latin:keyHintLabel="/"
+                latin:additionalMoreKeys="/" />
+        </case>
+        <default>
+            <Key
+                latin:keySpec="a"
+                latin:moreKeys="!text/morekeys_a" />
+            <Key
+                latin:keySpec="o"
+                latin:moreKeys="!text/morekeys_o" />
+            <Key
+                latin:keySpec="e"
+                latin:moreKeys="!text/morekeys_e" />
+            <Key
+                latin:keySpec="u"
+                latin:moreKeys="!text/morekeys_u" />
+            <Key
+                latin:keySpec="i"
+                latin:moreKeys="!text/morekeys_i" />
+            <Key
+                latin:keySpec="d"
+                latin:moreKeys="!text/morekeys_d" />
+            <Key
+                latin:keySpec="h"
+                latin:moreKeys="!text/morekeys_h" />
+            <Key
+                latin:keySpec="t"
+                latin:moreKeys="!text/morekeys_t" />
+            <Key
+                latin:keySpec="n"
+                latin:moreKeys="!text/morekeys_n" />
+            <Key
+                latin:keySpec="s"
+                latin:moreKeys="!text/morekeys_s" />
+        </default>
+    </switch>
 </merge>

--- a/app/src/main/res/xml/rowkeys_dvorak3.xml
+++ b/app/src/main/res/xml/rowkeys_dvorak3.xml
@@ -21,22 +21,60 @@
 <merge
     xmlns:latin="http://schemas.android.com/apk/res-auto"
 >
-    <Key
-        latin:keySpec="j"
-        latin:moreKeys="!text/morekeys_j" />
-    <Key
-        latin:keySpec="k"
-        latin:moreKeys="!text/morekeys_k" />
-    <Key
-        latin:keySpec="x" />
-    <Key
-        latin:keySpec="b" />
-    <Key
-        latin:keySpec="m" />
-    <Key
-        latin:keySpec="w"
-        latin:moreKeys="!text/morekeys_w" />
-    <Key
-        latin:keySpec="v"
-        latin:moreKeys="!text/morekeys_v" />
+    <switch>
+        <case latin:showExtraChars="true">
+            <Key
+                latin:keySpec="j"
+                latin:moreKeys="!text/morekeys_j"
+                latin:keyHintLabel="*"
+                latin:additionalMoreKeys="*" />
+            <Key
+                latin:keySpec="k"
+                latin:moreKeys="!text/morekeys_k"
+                latin:keyHintLabel="&quot;"
+                latin:additionalMoreKeys="&quot;" />
+            <Key
+                latin:keySpec="x"
+                latin:keyHintLabel="&apos;"
+                latin:additionalMoreKeys="&apos;" />
+            <Key
+                latin:keySpec="b"
+                latin:keyHintLabel=":"
+                latin:additionalMoreKeys=":" />
+            <Key
+                latin:keySpec="m"
+                latin:keyHintLabel=";"
+                latin:additionalMoreKeys=";" />
+            <Key
+                latin:keySpec="w"
+                latin:moreKeys="!text/morekeys_w"
+                latin:keyHintLabel="!"
+                latin:additionalMoreKeys="!" />
+            <Key
+                latin:keySpec="v"
+                latin:moreKeys="!text/morekeys_v"
+                latin:keyHintLabel="\?"
+                latin:additionalMoreKeys="\?" />
+        </case>
+        <default>
+            <Key
+                latin:keySpec="j"
+                latin:moreKeys="!text/morekeys_j" />
+            <Key
+                latin:keySpec="k"
+                latin:moreKeys="!text/morekeys_k" />
+            <Key
+                latin:keySpec="x" />
+            <Key
+                latin:keySpec="b" />
+            <Key
+                latin:keySpec="m" />
+            <Key
+                latin:keySpec="w"
+                latin:moreKeys="!text/morekeys_w" />
+            <Key
+                latin:keySpec="v"
+                latin:moreKeys="!text/morekeys_v" />
+        </default>
+    </switch>
 </merge>


### PR DESCRIPTION
The azerty, colemak, and dvorak keyboards were missing the extra characters on the keys, so I added them. Also, the dvorak keyboard didn't show a separate number row when the setting was used, so I added support for that.