### PR TITLE
Add extra characters to the top letter row

### DIFF
--- a/app/src/main/res/xml-sw600dp/keys_dvorak_123.xml
+++ b/app/src/main/res/xml-sw600dp/keys_dvorak_123.xml
@@ -22,6 +22,45 @@
     xmlns:latin="http://schemas.android.com/apk/res-auto"
 >
     <switch>
+        <case
+            latin:showNumberRow="true"
+            latin:showExtraChars="true">
+            <switch>
+                <case
+                    latin:keyboardLayoutSetElement="alphabetManualShifted|alphabetShiftLocked|alphabetShiftLockShifted"
+                    >
+                    <Key
+                        latin:keySpec="&quot;"
+                        latin:keyHintLabel="_"
+                        latin:additionalMoreKeys="_" />
+                    <Key
+                        latin:keySpec="&lt;"
+                        latin:keyHintLabel="\\"
+                        latin:additionalMoreKeys="\\\\" />
+                    <Key
+                        latin:keySpec="&gt;"
+                        latin:keyHintLabel="|"
+                        latin:additionalMoreKeys="\\|" />
+                </case>
+                <default>
+                    <Key
+                        latin:keySpec="\'"
+                        latin:keyHintLabel="_"
+                        latin:additionalMoreKeys="_"
+                        latin:moreKeys="!,&quot;" />
+                    <Key
+                        latin:keySpec=","
+                        latin:keyHintLabel="\\"
+                        latin:additionalMoreKeys="\\\\"
+                        latin:moreKeys="\?,&lt;" />
+                    <Key
+                        latin:keySpec="."
+                        latin:keyHintLabel="|"
+                        latin:additionalMoreKeys="\\|"
+                        latin:moreKeys="&gt;" />
+                </default>
+            </switch>
+        </case>
         <case latin:showNumberRow="true">
             <switch>
                 <case

--- a/app/src/main/res/xml/keys_dvorak_123.xml
+++ b/app/src/main/res/xml/keys_dvorak_123.xml
@@ -22,6 +22,69 @@
     xmlns:latin="http://schemas.android.com/apk/res-auto"
 >
     <switch>
+        <case
+            latin:showNumberRow="true"
+            latin:showExtraChars="true">
+            <switch>
+                <case
+                    latin:keyboardLayoutSetElement="alphabetManualShifted|alphabetShiftLocked|alphabetShiftLockShifted"
+                    >
+                    <Key
+                        latin:keySpec="&quot;"
+                        latin:keyHintLabel="_"
+                        latin:additionalMoreKeys="_" />
+                </case>
+                <case
+                    latin:mode="url"
+                    >
+                    <Key
+                        latin:keySpec="/"
+                        latin:keyHintLabel="_"
+                        latin:additionalMoreKeys="_" />
+                </case>
+                <case
+                    latin:mode="email"
+                    >
+                    <Key
+                        latin:keySpec="\@"
+                        latin:keyHintLabel="_"
+                        latin:additionalMoreKeys="_" />
+                </case>
+                <default>
+                    <Key
+                        latin:keySpec="\'"
+                        latin:keyHintLabel="_"
+                        latin:additionalMoreKeys="_"
+                        latin:moreKeys="!,&quot;" />
+                </default>
+            </switch>
+            <switch>
+                <case
+                    latin:keyboardLayoutSetElement="alphabetManualShifted|alphabetShiftLocked|alphabetShiftLockShifted"
+                    >
+                    <Key
+                        latin:keySpec="&lt;"
+                        latin:keyHintLabel="\\"
+                        latin:additionalMoreKeys="\\\\" />
+                    <Key
+                        latin:keySpec="&gt;"
+                        latin:keyHintLabel="|"
+                        latin:additionalMoreKeys="\\|" />
+                </case>
+                <default>
+                    <Key
+                        latin:keySpec=","
+                        latin:keyHintLabel="\\"
+                        latin:additionalMoreKeys="\\\\"
+                        latin:moreKeys="\?,&lt;" />
+                    <Key
+                        latin:keySpec="."
+                        latin:keyHintLabel="|"
+                        latin:additionalMoreKeys="\\|"
+                        latin:moreKeys="&gt;" />
+                </default>
+            </switch>
+        </case>
         <case latin:showNumberRow="true">
             <switch>
                 <case

--- a/app/src/main/res/xml/rowkeys_abc1.xml
+++ b/app/src/main/res/xml/rowkeys_abc1.xml
@@ -22,6 +22,58 @@
     xmlns:latin="http://schemas.android.com/apk/res-auto"
 >
     <switch>
+        <case
+            latin:showNumberRow="true"
+            latin:showExtraChars="true">
+            <Key
+                latin:keySpec="a"
+                latin:keyHintLabel="_"
+                latin:additionalMoreKeys="_"
+                latin:moreKeys="!text/morekeys_a" />
+            <Key
+                latin:keySpec="b"
+                latin:keyHintLabel="\\"
+                latin:additionalMoreKeys="\\\\" />
+            <Key
+                latin:keySpec="c"
+                latin:keyHintLabel="|"
+                latin:additionalMoreKeys="\\|"
+                latin:moreKeys="!text/morekeys_c" />
+            <Key
+                latin:keySpec="d"
+                latin:keyHintLabel="="
+                latin:additionalMoreKeys="="
+                latin:moreKeys="!text/morekeys_d" />
+            <Key
+                latin:keySpec="e"
+                latin:keyHintLabel="["
+                latin:additionalMoreKeys="!text/keyspec_left_square_bracket"
+                latin:moreKeys="!text/morekeys_e" />
+            <Key
+                latin:keySpec="f"
+                latin:keyHintLabel="]"
+                latin:additionalMoreKeys="!text/keyspec_right_square_bracket" />
+            <Key
+                latin:keySpec="g"
+                latin:keyHintLabel="&lt;"
+                latin:additionalMoreKeys="!text/keyspec_less_than"
+                latin:moreKeys="!text/morekeys_g" />
+            <Key
+                latin:keySpec="h"
+                latin:keyHintLabel="&gt;"
+                latin:additionalMoreKeys="!text/keyspec_greater_than"
+                latin:moreKeys="!text/morekeys_h" />
+            <Key
+                latin:keySpec="i"
+                latin:keyHintLabel="{"
+                latin:additionalMoreKeys="!text/keyspec_left_curly_bracket"
+                latin:moreKeys="!text/morekeys_i" />
+            <Key
+                latin:keySpec="j"
+                latin:keyHintLabel="}"
+                latin:additionalMoreKeys="!text/keyspec_right_curly_bracket"
+                latin:moreKeys="!text/morekeys_j" />
+        </case>
         <case latin:showNumberRow="true">
             <Key
                 latin:keySpec="a"

--- a/app/src/main/res/xml/rowkeys_azerty1.xml
+++ b/app/src/main/res/xml/rowkeys_azerty1.xml
@@ -22,6 +22,59 @@
     xmlns:latin="http://schemas.android.com/apk/res-auto"
 >
     <switch>
+        <case
+            latin:showNumberRow="true"
+            latin:showExtraChars="true">
+            <Key
+                latin:keySpec="a"
+                latin:keyHintLabel="_"
+                latin:additionalMoreKeys="_"
+                latin:moreKeys="!text/morekeys_a" />
+            <Key
+                latin:keySpec="z"
+                latin:keyHintLabel="\\"
+                latin:additionalMoreKeys="\\\\"
+                latin:moreKeys="!text/morekeys_z" />
+            <Key
+                latin:keySpec="e"
+                latin:keyHintLabel="|"
+                latin:additionalMoreKeys="\\|"
+                latin:moreKeys="!text/morekeys_e" />
+            <Key
+                latin:keySpec="r"
+                latin:keyHintLabel="="
+                latin:additionalMoreKeys="="
+                latin:moreKeys="!text/morekeys_r" />
+            <Key
+                latin:keySpec="t"
+                latin:keyHintLabel="["
+                latin:additionalMoreKeys="!text/keyspec_left_square_bracket"
+                latin:moreKeys="!text/morekeys_t" />
+            <Key
+                latin:keySpec="y"
+                latin:keyHintLabel="]"
+                latin:additionalMoreKeys="!text/keyspec_right_square_bracket"
+                latin:moreKeys="!text/morekeys_y" />
+            <Key
+                latin:keySpec="u"
+                latin:keyHintLabel="&lt;"
+                latin:additionalMoreKeys="!text/keyspec_less_than"
+                latin:moreKeys="!text/morekeys_u" />
+            <Key
+                latin:keySpec="i"
+                latin:keyHintLabel="&gt;"
+                latin:additionalMoreKeys="!text/keyspec_greater_than"
+                latin:moreKeys="!text/morekeys_i" />
+            <Key
+                latin:keySpec="o"
+                latin:keyHintLabel="{"
+                latin:additionalMoreKeys="!text/keyspec_left_curly_bracket"
+                latin:moreKeys="!text/morekeys_o" />
+            <Key
+                latin:keySpec="p"
+                latin:keyHintLabel="}"
+                latin:additionalMoreKeys="!text/keyspec_right_curly_bracket" />
+        </case>
         <case latin:showNumberRow="true">
             <Key
                 latin:keySpec="a"

--- a/app/src/main/res/xml/rowkeys_colemak1.xml
+++ b/app/src/main/res/xml/rowkeys_colemak1.xml
@@ -22,6 +22,68 @@
     xmlns:latin="http://schemas.android.com/apk/res-auto"
 >
     <switch>
+        <case
+            latin:showNumberRow="true"
+            latin:showExtraChars="true">
+            <Key
+                latin:keySpec="q"
+                latin:keyHintLabel="_"
+                latin:additionalMoreKeys="_" />
+            <Key
+                latin:keySpec="w"
+                latin:keyHintLabel="\\"
+                latin:additionalMoreKeys="\\\\"
+                latin:moreKeys="!text/morekeys_w" />
+            <Key
+                latin:keySpec="f"
+                latin:keyHintLabel="|"
+                latin:additionalMoreKeys="\\|" />
+            <Key
+                latin:keySpec="p"
+                latin:keyHintLabel="="
+                latin:additionalMoreKeys="=" />
+            <Key
+                latin:keySpec="g"
+                latin:keyHintLabel="["
+                latin:additionalMoreKeys="!text/keyspec_left_square_bracket"
+                latin:moreKeys="!text/morekeys_g" />
+            <Key
+                latin:keySpec="j"
+                latin:keyHintLabel="]"
+                latin:additionalMoreKeys="!text/keyspec_right_square_bracket"
+                latin:moreKeys="!text/morekeys_j" />
+            <Key
+                latin:keySpec="l"
+                latin:keyHintLabel="&lt;"
+                latin:additionalMoreKeys="!text/keyspec_less_than"
+                latin:moreKeys="!text/morekeys_l" />
+            <Key
+                latin:keySpec="u"
+                latin:keyHintLabel="&gt;"
+                latin:additionalMoreKeys="!text/keyspec_greater_than"
+                latin:moreKeys="!text/morekeys_u" />
+            <Key
+                latin:keySpec="y"
+                latin:keyHintLabel="{"
+                latin:additionalMoreKeys="!text/keyspec_left_curly_bracket"
+                latin:moreKeys="!text/morekeys_y" />
+            <switch>
+                <case
+                    latin:keyboardLayoutSetElement="alphabetManualShifted|alphabetShiftLockShifted"
+                    >
+                    <Key
+                        latin:keySpec=":"
+                        latin:keyHintLabel="}"
+                        latin:additionalMoreKeys="!text/keyspec_right_curly_bracket" />
+                </case>
+                <default>
+                    <Key
+                        latin:keySpec=";"
+                        latin:keyHintLabel="}"
+                        latin:additionalMoreKeys="!text/keyspec_right_curly_bracket,:" />
+                </default>
+            </switch>
+        </case>
         <case latin:showNumberRow="true">
             <Key
                 latin:keySpec="q" />
@@ -53,12 +115,6 @@
                 >
                     <Key
                         latin:keySpec=":" />
-                </case>
-                <case latin:showExtraChars="true">
-                    <Key
-                        latin:keySpec=";"
-                        latin:keyHintLabel=":"
-                        latin:additionalMoreKeys=":" />
                 </case>
                 <default>
                     <Key

--- a/app/src/main/res/xml/rowkeys_dvorak1.xml
+++ b/app/src/main/res/xml/rowkeys_dvorak1.xml
@@ -24,6 +24,43 @@
     <include
         latin:keyboardLayout="@xml/keys_dvorak_123" />
     <switch>
+        <case
+            latin:showNumberRow="true"
+            latin:showExtraChars="true">
+            <Key
+                latin:keySpec="p"
+                latin:keyHintLabel="="
+                latin:additionalMoreKeys="=" />
+            <Key
+                latin:keySpec="y"
+                latin:keyHintLabel="["
+                latin:additionalMoreKeys="!text/keyspec_left_square_bracket"
+                latin:moreKeys="!text/morekeys_y" />
+            <Key
+                latin:keySpec="f"
+                latin:keyHintLabel="]"
+                latin:additionalMoreKeys="!text/keyspec_right_square_bracket" />
+            <Key
+                latin:keySpec="g"
+                latin:keyHintLabel="&lt;"
+                latin:additionalMoreKeys="!text/keyspec_less_than"
+                latin:moreKeys="!text/morekeys_g" />
+            <Key
+                latin:keySpec="c"
+                latin:keyHintLabel="&gt;"
+                latin:additionalMoreKeys="!text/keyspec_greater_than"
+                latin:moreKeys="!text/morekeys_c" />
+            <Key
+                latin:keySpec="r"
+                latin:keyHintLabel="{"
+                latin:additionalMoreKeys="!text/keyspec_left_curly_bracket"
+                latin:moreKeys="!text/morekeys_r" />
+            <Key
+                latin:keySpec="l"
+                latin:keyHintLabel="}"
+                latin:additionalMoreKeys="!text/keyspec_right_curly_bracket"
+                latin:moreKeys="!text/morekeys_l" />
+        </case>
         <case latin:showNumberRow="true">
             <Key
                 latin:keySpec="p" />

--- a/app/src/main/res/xml/rowkeys_east_slavic1.xml
+++ b/app/src/main/res/xml/rowkeys_east_slavic1.xml
@@ -22,6 +22,70 @@
     xmlns:latin="http://schemas.android.com/apk/res-auto"
 >
     <switch>
+        <case
+            latin:showNumberRow="true"
+            latin:showExtraChars="true">
+            <!-- U+0439: "й" CYRILLIC SMALL LETTER SHORT I -->
+            <Key
+                latin:keySpec="&#x0439;"
+                latin:keyHintLabel="\\"
+                latin:additionalMoreKeys="\\\\" />
+            <!-- U+0446: "ц" CYRILLIC SMALL LETTER TSE -->
+            <Key
+                latin:keySpec="&#x0446;"
+                latin:keyHintLabel="|"
+                latin:additionalMoreKeys="\\|" />
+            <!-- U+0443: "у" CYRILLIC SMALL LETTER U -->
+            <Key
+                latin:keySpec="&#x0443;"
+                latin:keyHintLabel="="
+                latin:additionalMoreKeys="="
+                latin:moreKeys="!text/morekeys_cyrillic_u" />
+            <!-- U+043A: "к" CYRILLIC SMALL LETTER KA -->
+            <Key
+                latin:keySpec="&#x043A;"
+                latin:keyHintLabel="["
+                latin:additionalMoreKeys="!text/keyspec_left_square_bracket"
+                latin:moreKeys="!text/morekeys_cyrillic_ka" />
+            <!-- U+0435: "е" CYRILLIC SMALL LETTER IE -->
+            <Key
+                latin:keySpec="&#x0435;"
+                latin:keyHintLabel="]"
+                latin:additionalMoreKeys="!text/keyspec_right_square_bracket"
+                latin:moreKeys="!text/morekeys_cyrillic_ie" />
+            <!-- U+043D: "н" CYRILLIC SMALL LETTER EN -->
+            <Key
+                latin:keySpec="&#x043D;"
+                latin:keyHintLabel="{"
+                latin:additionalMoreKeys="!text/keyspec_left_curly_bracket"
+                latin:moreKeys="!text/morekeys_cyrillic_en" />
+            <!-- U+0433: "г" CYRILLIC SMALL LETTER GHE -->
+            <Key
+                latin:keySpec="&#x0433;"
+                latin:keyHintLabel="}"
+                latin:additionalMoreKeys="!text/keyspec_right_curly_bracket"
+                latin:moreKeys="!text/morekeys_cyrillic_ghe" />
+            <!-- U+0448: "ш" CYRILLIC SMALL LETTER SHA -->
+            <Key
+                latin:keySpec="&#x0448;"
+                latin:keyHintLabel="~"
+                latin:additionalMoreKeys="~" />
+            <!-- U+00B0: "°" DEGREE SIGN -->
+            <Key
+                latin:keySpec="!text/keyspec_east_slavic_row1_9"
+                latin:keyHintLabel="&#x00B0;"
+                latin:additionalMoreKeys="&#x00B0;" />
+            <!-- U+0437: "з" CYRILLIC SMALL LETTER ZE -->
+            <Key
+                latin:keySpec="&#x0437;"
+                latin:keyHintLabel="^"
+                latin:additionalMoreKeys="^" />
+            <!-- U+0445: "х" CYRILLIC SMALL LETTER HA -->
+            <Key
+                latin:keySpec="&#x0445;"
+                latin:keyHintLabel="`"
+                latin:additionalMoreKeys="`" />
+        </case>
         <case latin:showNumberRow="true">
             <!-- U+0439: "й" CYRILLIC SMALL LETTER SHORT I -->
             <Key
@@ -57,6 +121,9 @@
             <!-- U+0437: "з" CYRILLIC SMALL LETTER ZE -->
             <Key
                 latin:keySpec="&#x0437;" />
+            <!-- U+0445: "х" CYRILLIC SMALL LETTER HA -->
+            <Key
+                latin:keySpec="&#x0445;" />
         </case>
         <default>
             <!-- U+0439: "й" CYRILLIC SMALL LETTER SHORT I -->
@@ -113,9 +180,9 @@
                 latin:keySpec="&#x0437;"
                 latin:keyHintLabel="0"
                 latin:additionalMoreKeys="0" />
+            <!-- U+0445: "х" CYRILLIC SMALL LETTER HA -->
+            <Key
+                latin:keySpec="&#x0445;" />
         </default>
     </switch>
-    <!-- U+0445: "х" CYRILLIC SMALL LETTER HA -->
-    <Key
-        latin:keySpec="&#x0445;" />
 </merge>

--- a/app/src/main/res/xml/rowkeys_greek1.xml
+++ b/app/src/main/res/xml/rowkeys_greek1.xml
@@ -22,21 +22,114 @@
     xmlns:latin="http://schemas.android.com/apk/res-auto"
 >
     <switch>
+        <case
+            latin:showNumberRow="true"
+            latin:showExtraChars="true">
+            <switch>
+                <case
+                    latin:keyboardLayoutSetElement="alphabetManualShifted|alphabetShiftLockShifted"
+                    >
+                    <Key
+                        latin:keySpec=":"
+                        latin:keyHintLabel="_"
+                        latin:additionalMoreKeys="_,;" />
+                </case>
+                <default>
+                    <Key
+                        latin:keySpec=";"
+                        latin:keyHintLabel="_"
+                        latin:additionalMoreKeys="_,:" />
+                </default>
+            </switch>
+            <!-- TODO: Should find a way to compound Greek dialytika tonos and other Greek letters. -->
+            <!--
+            <switch>
+                <case
+                    latin:keyboardLayoutSetElement="alphabetManualShifted|alphabetShiftLockShifted"
+                >
+                    U+0385: "΅" GREEK DIALYTIKA TONOS
+                    <Key
+                        latin:keySpec="&#x0385;"
+                        latin:keyHintLabel="\\"
+                        latin:additionalMoreKeys="\\\\" />
+                </case>
+                <default>
+                -->
+            <!-- U+03C2: "ς" GREEK SMALL LETTER FINAL SIGMA -->
+            <Key
+                latin:keySpec="&#x03C2;"
+                latin:keyHintLabel="\\"
+                latin:additionalMoreKeys="\\\\"
+                latin:keyLabelFlags="preserveCase" />
+            <!--
+                </default>
+            </switch>
+                -->
+            <!-- U+03B5: "ε" GREEK SMALL LETTER EPSILON
+                 U+03AD: "έ" GREEK SMALL LETTER EPSILON WITH TONOS -->
+            <Key
+                latin:keySpec="&#x03B5;"
+                latin:keyHintLabel="|"
+                latin:additionalMoreKeys="\\|"
+                latin:moreKeys="&#x03AD;,%" />
+            <!-- U+03C1: "ρ" GREEK SMALL LETTER RHO -->
+            <Key
+                latin:keySpec="&#x03C1;"
+                latin:keyHintLabel="="
+                latin:additionalMoreKeys="=" />
+            <!-- U+03C4: "τ" GREEK SMALL LETTER TAU -->
+            <Key
+                latin:keySpec="&#x03C4;"
+                latin:keyHintLabel="["
+                latin:additionalMoreKeys="!text/keyspec_left_square_bracket" />
+            <!-- U+03C5: "υ" GREEK SMALL LETTER UPSILON
+                 U+03CD: "ύ" GREEK SMALL LETTER UPSILON WITH TONOS
+                 U+03CB: "ϋ" GREEK SMALL LETTER UPSILON WITH DIALYTIKA
+                 U+03B0: "ΰ" GREEK SMALL LETTER UPSILON WITH DIALYTIKA AND TONOS -->
+            <Key
+                latin:keySpec="&#x03C5;"
+                latin:keyHintLabel="]"
+                latin:additionalMoreKeys="!text/keyspec_right_square_bracket"
+                latin:moreKeys="&#x03CD;,%,&#x03CB;,&#x03B0;" />
+            <!-- U+03B8: "θ" GREEK SMALL LETTER THETA -->
+            <Key
+                latin:keySpec="&#x03B8;"
+                latin:keyHintLabel="&lt;"
+                latin:additionalMoreKeys="!text/keyspec_less_than" />
+            <!-- U+03B9: "ι" GREEK SMALL LETTER IOTA
+                 U+03AF: "ί" GREEK SMALL LETTER IOTA WITH TONOS
+                 U+03CA: "ϊ" GREEK SMALL LETTER IOTA WITH DIALYTIKA
+                 U+0390: "ΐ" GREEK SMALL LETTER IOTA WITH DIALYTIKA AND TONOS -->
+            <Key
+                latin:keySpec="&#x03B9;"
+                latin:keyHintLabel="&gt;"
+                latin:additionalMoreKeys="!text/keyspec_greater_than"
+                latin:moreKeys="&#x03AF;,%,&#x03CA;,&#x0390;" />
+            <!-- U+03BF: "ο" GREEK SMALL LETTER OMICRON
+                 U+03CC: "ό" GREEK SMALL LETTER OMICRON WITH TONOS -->
+            <Key
+                latin:keySpec="&#x03BF;"
+                latin:keyHintLabel="{"
+                latin:additionalMoreKeys="!text/keyspec_left_curly_bracket"
+                latin:moreKeys="&#x03CC;,%" />
+            <!-- U+03C0: "π" GREEK SMALL LETTER PI -->
+            <Key
+                latin:keySpec="&#x03C0;"
+                latin:keyHintLabel="}"
+                latin:additionalMoreKeys="!text/keyspec_right_curly_bracket" />
+        </case>
+
         <case latin:showNumberRow="true">
             <switch>
                 <case
                     latin:keyboardLayoutSetElement="alphabetManualShifted|alphabetShiftLockShifted"
                 >
                     <Key
-                        latin:keySpec=":"
-                        latin:keyHintLabel=";"
-                        latin:additionalMoreKeys=";" />
+                        latin:keySpec=":" />
                 </case>
                 <default>
                     <Key
-                        latin:keySpec=";"
-                        latin:keyHintLabel=":"
-                        latin:additionalMoreKeys=":" />
+                        latin:keySpec=";" />
                 </default>
             </switch>
             <!-- TODO: Should find a way to compound Greek dialytika tonos and other Greek letters. -->

--- a/app/src/main/res/xml/rowkeys_qwerty1.xml
+++ b/app/src/main/res/xml/rowkeys_qwerty1.xml
@@ -22,6 +22,59 @@
     xmlns:latin="http://schemas.android.com/apk/res-auto"
 >
     <switch>
+        <case
+            latin:showNumberRow="true"
+            latin:showExtraChars="true">
+            <Key
+                latin:keySpec="!text/keyspec_q"
+                latin:keyHintLabel="_"
+                latin:additionalMoreKeys="_"
+                latin:moreKeys="!text/morekeys_q" />
+            <Key
+                latin:keySpec="!text/keyspec_w"
+                latin:keyHintLabel="\\"
+                latin:additionalMoreKeys="\\\\"
+                latin:moreKeys="!text/morekeys_w" />
+            <Key
+                latin:keySpec="e"
+                latin:keyHintLabel="|"
+                latin:additionalMoreKeys="\\|"
+                latin:moreKeys="!text/morekeys_e" />
+            <Key
+                latin:keySpec="r"
+                latin:keyHintLabel="="
+                latin:additionalMoreKeys="="
+                latin:moreKeys="!text/morekeys_r" />
+            <Key
+                latin:keySpec="t"
+                latin:keyHintLabel="["
+                latin:additionalMoreKeys="!text/keyspec_left_square_bracket"
+                latin:moreKeys="!text/morekeys_t" />
+            <Key
+                latin:keySpec="!text/keyspec_y"
+                latin:keyHintLabel="]"
+                latin:additionalMoreKeys="!text/keyspec_right_square_bracket"
+                latin:moreKeys="!text/morekeys_y" />
+            <Key
+                latin:keySpec="u"
+                latin:keyHintLabel="&lt;"
+                latin:additionalMoreKeys="!text/keyspec_less_than"
+                latin:moreKeys="!text/morekeys_u" />
+            <Key
+                latin:keySpec="i"
+                latin:keyHintLabel="&gt;"
+                latin:additionalMoreKeys="!text/keyspec_greater_than"
+                latin:moreKeys="!text/morekeys_i" />
+            <Key
+                latin:keySpec="o"
+                latin:keyHintLabel="{"
+                latin:additionalMoreKeys="!text/keyspec_left_curly_bracket"
+                latin:moreKeys="!text/morekeys_o" />
+            <Key
+                latin:keySpec="p"
+                latin:keyHintLabel="}"
+                latin:additionalMoreKeys="!text/keyspec_right_curly_bracket" />
+        </case>
         <case latin:showNumberRow="true">
             <Key
                 latin:keySpec="!text/keyspec_q"

--- a/app/src/main/res/xml/rowkeys_qwertz1.xml
+++ b/app/src/main/res/xml/rowkeys_qwertz1.xml
@@ -22,6 +22,58 @@
     xmlns:latin="http://schemas.android.com/apk/res-auto"
 >
     <switch>
+        <case
+            latin:showNumberRow="true"
+            latin:showExtraChars="true">
+            <Key
+                latin:keySpec="q"
+                latin:keyHintLabel="_"
+                latin:additionalMoreKeys="_" />
+            <Key
+                latin:keySpec="w"
+                latin:keyHintLabel="\\"
+                latin:additionalMoreKeys="\\\\"
+                latin:moreKeys="!text/morekeys_w" />
+            <Key
+                latin:keySpec="e"
+                latin:keyHintLabel="|"
+                latin:additionalMoreKeys="\\|"
+                latin:moreKeys="!text/morekeys_e" />
+            <Key
+                latin:keySpec="r"
+                latin:keyHintLabel="="
+                latin:additionalMoreKeys="="
+                latin:moreKeys="!text/morekeys_r" />
+            <Key
+                latin:keySpec="t"
+                latin:keyHintLabel="["
+                latin:additionalMoreKeys="!text/keyspec_left_square_bracket"
+                latin:moreKeys="!text/morekeys_t" />
+            <Key
+                latin:keySpec="z"
+                latin:keyHintLabel="]"
+                latin:additionalMoreKeys="!text/keyspec_right_square_bracket"
+                latin:moreKeys="!text/morekeys_z" />
+            <Key
+                latin:keySpec="u"
+                latin:keyHintLabel="&lt;"
+                latin:additionalMoreKeys="!text/keyspec_less_than"
+                latin:moreKeys="!text/morekeys_u" />
+            <Key
+                latin:keySpec="i"
+                latin:keyHintLabel="&gt;"
+                latin:additionalMoreKeys="!text/keyspec_greater_than"
+                latin:moreKeys="!text/morekeys_i" />
+            <Key
+                latin:keySpec="o"
+                latin:keyHintLabel="{"
+                latin:additionalMoreKeys="!text/keyspec_left_curly_bracket"
+                latin:moreKeys="!text/morekeys_o" />
+            <Key
+                latin:keySpec="p"
+                latin:keyHintLabel="}"
+                latin:additionalMoreKeys="!text/keyspec_right_curly_bracket" />
+        </case>
         <case latin:showNumberRow="true">
             <Key
                 latin:keySpec="q" />


### PR DESCRIPTION
When the number row is shown and extra characters are not disabled, the top row of letters will also have extra characters now. This fixes #74, except for the suggestion for extra customization, but that probably should be a separate issue.

I used `_`, `\`, `|`, `=`, `[`, `]`, `<`, `>`, `{`, `}` for most of the keyboards, which matches Gboard, other than the the `%` and `_` flipped because SimpleKeyboard already used `%` on the second letter row where Gboard uses `_`. The East Slavic keyboard had a few extra keys, some of which already used some of the characters I was adding to the top row, so I also added `~`, `°`, `^`, `` ` ``, some of which are what Gboard used, but it has some redundant characters, so I added a couple that it didn't have (I'm not sure if there are better options, but something is probably better than nothing). Also, Colemak's and Greek's `;` key already had an extra character, so I just added the new character to the key and used the new one as the hint because that is how Gboard handles it and the previous extra key was already used on a different key and shift already changes the key to use it.

I only implemented this for keyboards that already support a separate number row and use extra characters.