### PR TITLE
Remove alphabetShiftLockShifted state and check exit state from auto-capitalization

### DIFF
--- a/app/src/main/java/rkr/simplekeyboard/inputmethod/keyboard/Key.java
+++ b/app/src/main/java/rkr/simplekeyboard/inputmethod/keyboard/Key.java
@@ -423,7 +423,6 @@ public class Key implements Comparable<Key> {
         case KeyboardId.ELEMENT_ALPHABET_MANUAL_SHIFTED:
         case KeyboardId.ELEMENT_ALPHABET_AUTOMATIC_SHIFTED:
         case KeyboardId.ELEMENT_ALPHABET_SHIFT_LOCKED:
-        case KeyboardId.ELEMENT_ALPHABET_SHIFT_LOCK_SHIFTED:
             return true;
         default:
             return false;

--- a/app/src/main/java/rkr/simplekeyboard/inputmethod/keyboard/KeyboardId.java
+++ b/app/src/main/java/rkr/simplekeyboard/inputmethod/keyboard/KeyboardId.java
@@ -47,7 +47,6 @@ public final class KeyboardId {
     public static final int ELEMENT_ALPHABET_MANUAL_SHIFTED = 1;
     public static final int ELEMENT_ALPHABET_AUTOMATIC_SHIFTED = 2;
     public static final int ELEMENT_ALPHABET_SHIFT_LOCKED = 3;
-    public static final int ELEMENT_ALPHABET_SHIFT_LOCK_SHIFTED = 4;
     public static final int ELEMENT_SYMBOLS = 5;
     public static final int ELEMENT_SYMBOLS_SHIFTED = 6;
     public static final int ELEMENT_PHONE = 7;
@@ -194,7 +193,6 @@ public final class KeyboardId {
         case ELEMENT_ALPHABET_MANUAL_SHIFTED: return "alphabetManualShifted";
         case ELEMENT_ALPHABET_AUTOMATIC_SHIFTED: return "alphabetAutomaticShifted";
         case ELEMENT_ALPHABET_SHIFT_LOCKED: return "alphabetShiftLocked";
-        case ELEMENT_ALPHABET_SHIFT_LOCK_SHIFTED: return "alphabetShiftLockShifted";
         case ELEMENT_SYMBOLS: return "symbols";
         case ELEMENT_SYMBOLS_SHIFTED: return "symbolsShifted";
         case ELEMENT_PHONE: return "phone";

--- a/app/src/main/java/rkr/simplekeyboard/inputmethod/keyboard/KeyboardSwitcher.java
+++ b/app/src/main/java/rkr/simplekeyboard/inputmethod/keyboard/KeyboardSwitcher.java
@@ -219,15 +219,6 @@ public final class KeyboardSwitcher implements KeyboardState.SwitchActions {
 
     // Implements {@link KeyboardState.SwitchActions}.
     @Override
-    public void setAlphabetShiftLockShiftedKeyboard() {
-        if (DEBUG_ACTION) {
-            Log.d(TAG, "setAlphabetShiftLockShiftedKeyboard");
-        }
-        setKeyboard(KeyboardId.ELEMENT_ALPHABET_SHIFT_LOCK_SHIFTED, KeyboardSwitchState.OTHER);
-    }
-
-    // Implements {@link KeyboardState.SwitchActions}.
-    @Override
     public void setSymbolsKeyboard() {
         if (DEBUG_ACTION) {
             Log.d(TAG, "setSymbolsKeyboard");

--- a/app/src/main/java/rkr/simplekeyboard/inputmethod/keyboard/internal/AlphabetShiftState.java
+++ b/app/src/main/java/rkr/simplekeyboard/inputmethod/keyboard/internal/AlphabetShiftState.java
@@ -24,10 +24,9 @@ public final class AlphabetShiftState {
 
     private static final int UNSHIFTED = 0;
     private static final int MANUAL_SHIFTED = 1;
-    private static final int MANUAL_SHIFTED_FROM_AUTO = 2;
-    private static final int AUTOMATIC_SHIFTED = 3;
-    private static final int SHIFT_LOCKED = 4;
-    private static final int SHIFT_LOCK_SHIFTED = 5;
+    private static final int AUTOMATIC_SHIFTED = 2;
+    private static final int SHIFT_LOCKED = 3;
+    private static final int SHIFT_LOCK_SHIFTED = 4;
 
     private int mState = UNSHIFTED;
 
@@ -38,9 +37,6 @@ public final class AlphabetShiftState {
             case UNSHIFTED:
                 mState = MANUAL_SHIFTED;
                 break;
-            case AUTOMATIC_SHIFTED:
-                mState = MANUAL_SHIFTED_FROM_AUTO;
-                break;
             case SHIFT_LOCKED:
                 mState = SHIFT_LOCK_SHIFTED;
                 break;
@@ -48,7 +44,6 @@ public final class AlphabetShiftState {
         } else {
             switch (oldState) {
             case MANUAL_SHIFTED:
-            case MANUAL_SHIFTED_FROM_AUTO:
             case AUTOMATIC_SHIFTED:
                 mState = UNSHIFTED;
                 break;
@@ -67,7 +62,6 @@ public final class AlphabetShiftState {
             switch (oldState) {
             case UNSHIFTED:
             case MANUAL_SHIFTED:
-            case MANUAL_SHIFTED_FROM_AUTO:
             case AUTOMATIC_SHIFTED:
                 mState = SHIFT_LOCKED;
                 break;
@@ -101,12 +95,7 @@ public final class AlphabetShiftState {
     }
 
     public boolean isManualShifted() {
-        return mState == MANUAL_SHIFTED || mState == MANUAL_SHIFTED_FROM_AUTO
-                || mState == SHIFT_LOCK_SHIFTED;
-    }
-
-    public boolean isManualShiftedFromAutomaticShifted() {
-        return mState == MANUAL_SHIFTED_FROM_AUTO;
+        return mState == MANUAL_SHIFTED || mState == SHIFT_LOCK_SHIFTED;
     }
 
     @Override
@@ -118,7 +107,6 @@ public final class AlphabetShiftState {
         switch (state) {
         case UNSHIFTED: return "UNSHIFTED";
         case MANUAL_SHIFTED: return "MANUAL_SHIFTED";
-        case MANUAL_SHIFTED_FROM_AUTO: return "MANUAL_SHIFTED_FROM_AUTO";
         case AUTOMATIC_SHIFTED: return "AUTOMATIC_SHIFTED";
         case SHIFT_LOCKED: return "SHIFT_LOCKED";
         case SHIFT_LOCK_SHIFTED: return "SHIFT_LOCK_SHIFTED";

--- a/app/src/main/java/rkr/simplekeyboard/inputmethod/keyboard/internal/KeyboardState.java
+++ b/app/src/main/java/rkr/simplekeyboard/inputmethod/keyboard/internal/KeyboardState.java
@@ -48,7 +48,6 @@ public final class KeyboardState {
         void setAlphabetManualShiftedKeyboard();
         void setAlphabetAutomaticShiftedKeyboard();
         void setAlphabetShiftLockedKeyboard();
-        void setAlphabetShiftLockShiftedKeyboard();
         void setSymbolsKeyboard();
         void setSymbolsShiftedKeyboard();
 
@@ -204,7 +203,7 @@ public final class KeyboardState {
             break;
         case MANUAL_SHIFT:
             mAlphabetShiftState.setShifted(true);
-            if (shiftMode != prevShiftMode) {
+            if (shiftMode != prevShiftMode && prevShiftMode != AUTOMATIC_SHIFT) {
                 mSwitchActions.setAlphabetManualShiftedKeyboard();
             }
             break;
@@ -216,7 +215,6 @@ public final class KeyboardState {
             break;
         case SHIFT_LOCK_SHIFTED:
             mAlphabetShiftState.setShifted(true);
-            mSwitchActions.setAlphabetShiftLockShiftedKeyboard();
             break;
         }
     }

--- a/app/src/main/java/rkr/simplekeyboard/inputmethod/keyboard/internal/KeyboardState.java
+++ b/app/src/main/java/rkr/simplekeyboard/inputmethod/keyboard/internal/KeyboardState.java
@@ -352,7 +352,8 @@ public final class KeyboardState {
             // shifted mode.
             if (!isSinglePointer && mIsAlphabetMode
                     && autoCapsFlags != TextUtils.CAP_MODE_CHARACTERS) {
-                final boolean needsToResetAutoCaps = mAlphabetShiftState.isAutomaticShifted()
+                final boolean needsToResetAutoCaps =
+                        (mAlphabetShiftState.isAutomaticShifted() && !mShiftKeyState.isChording())
                         || (mAlphabetShiftState.isManualShifted() && mShiftKeyState.isReleasing());
                 if (needsToResetAutoCaps) {
                     mSwitchActions.setAlphabetKeyboard();
@@ -484,9 +485,8 @@ public final class KeyboardState {
                     setShifted(SHIFT_LOCK_SHIFTED);
                     mShiftKeyState.onPress();
                 } else if (mAlphabetShiftState.isAutomaticShifted()) {
-                    // Shift key is pressed while automatic shifted, we have to move to manual
-                    // shifted.
-                    setShifted(MANUAL_SHIFT);
+                    // Shift key pressed while automatic shifted isn't considered a manual shift
+                    // since it doesn't change the keyboard into a shifted state.
                     mShiftKeyState.onPress();
                 } else if (mAlphabetShiftState.isShiftedOrShiftLocked()) {
                     // In manual shifted state, we just record shift key has been pressing while
@@ -550,10 +550,9 @@ public final class KeyboardState {
                 // Shift has been pressed without chording while shifted state.
                 setShifted(UNSHIFT);
                 mIsInAlphabetUnshiftedFromShifted = true;
-            } else if (mAlphabetShiftState.isManualShiftedFromAutomaticShifted()
-                    && mShiftKeyState.isPressing() && !withSliding) {
-                // Shift has been pressed without chording while manual shifted transited from
-                // automatic shifted
+            } else if (mAlphabetShiftState.isAutomaticShifted() && mShiftKeyState.isPressing()
+                    && !withSliding) {
+                // Shift has been pressed without chording while automatic shifted
                 setShifted(UNSHIFT);
                 mIsInAlphabetUnshiftedFromShifted = true;
             }

--- a/app/src/main/java/rkr/simplekeyboard/inputmethod/keyboard/internal/KeyboardState.java
+++ b/app/src/main/java/rkr/simplekeyboard/inputmethod/keyboard/internal/KeyboardState.java
@@ -203,7 +203,7 @@ public final class KeyboardState {
             break;
         case MANUAL_SHIFT:
             mAlphabetShiftState.setShifted(true);
-            if (shiftMode != prevShiftMode && prevShiftMode != AUTOMATIC_SHIFT) {
+            if (shiftMode != prevShiftMode) {
                 mSwitchActions.setAlphabetManualShiftedKeyboard();
             }
             break;

--- a/app/src/main/res/values/attrs.xml
+++ b/app/src/main/res/values/attrs.xml
@@ -322,7 +322,6 @@
             <enum name="alphabetManualShifted" value="1" />
             <enum name="alphabetAutomaticShifted" value="2" />
             <enum name="alphabetShiftLocked" value="3" />
-            <enum name="alphabetShiftLockShifted" value="4" />
             <enum name="symbols" value="5" />
             <enum name="symbolsShifted" value="6"  />
             <enum name="phone" value="7"  />
@@ -391,7 +390,6 @@
             <enum name="alphabetManualShifted" value="1" />
             <enum name="alphabetAutomaticShifted" value="2" />
             <enum name="alphabetShiftLocked" value="3" />
-            <enum name="alphabetShiftLockShifted" value="4" />
             <enum name="symbols" value="5" />
             <enum name="symbolsShifted" value="6"  />
             <enum name="phone" value="7"  />

--- a/app/src/main/res/xml-sw600dp/key_styles_common.xml
+++ b/app/src/main/res/xml-sw600dp/key_styles_common.xml
@@ -23,7 +23,7 @@
 >
     <switch>
         <case
-            latin:keyboardLayoutSetElement="alphabetManualShifted|alphabetShiftLockShifted"
+            latin:keyboardLayoutSetElement="alphabetManualShifted"
         >
             <key-style
                 latin:styleName="hasShiftedLetterHintStyle"
@@ -55,7 +55,7 @@
                 latin:parentStyle="baseForShiftKeyStyle" />
         </case>
         <case
-            latin:keyboardLayoutSetElement="alphabetShiftLocked|alphabetShiftLockShifted"
+            latin:keyboardLayoutSetElement="alphabetShiftLocked"
         >
             <key-style
                 latin:styleName="shiftKeyStyle"
@@ -110,7 +110,7 @@
         latin:backgroundType="functional" />
     <switch>
         <case
-            latin:keyboardLayoutSetElement="alphabetManualShifted|alphabetShiftLockShifted"
+            latin:keyboardLayoutSetElement="alphabetManualShifted"
             latin:navigatePrevious="true"
         >
             <key-style

--- a/app/src/main/res/xml-sw600dp/key_styles_enter.xml
+++ b/app/src/main/res/xml-sw600dp/key_styles_enter.xml
@@ -36,7 +36,7 @@
         <!-- Shift + Enter in textMultiLine field. -->
         <case
             latin:isMultiLine="true"
-            latin:keyboardLayoutSetElement="alphabetManualShifted|alphabetShiftLockShifted"
+            latin:keyboardLayoutSetElement="alphabetManualShifted"
         >
             <key-style
                 latin:styleName="enterKeyStyle"

--- a/app/src/main/res/xml-sw600dp/keys_dvorak_123.xml
+++ b/app/src/main/res/xml-sw600dp/keys_dvorak_123.xml
@@ -27,7 +27,7 @@
             latin:showExtraChars="true">
             <switch>
                 <case
-                    latin:keyboardLayoutSetElement="alphabetManualShifted|alphabetShiftLocked|alphabetShiftLockShifted"
+                    latin:keyboardLayoutSetElement="alphabetManualShifted|alphabetShiftLocked"
                     >
                     <Key
                         latin:keySpec="&quot;"
@@ -64,7 +64,7 @@
         <case latin:showNumberRow="true">
             <switch>
                 <case
-                    latin:keyboardLayoutSetElement="alphabetManualShifted|alphabetShiftLocked|alphabetShiftLockShifted"
+                    latin:keyboardLayoutSetElement="alphabetManualShifted|alphabetShiftLocked"
                     >
                     <Key
                         latin:keySpec="&quot;" />
@@ -89,7 +89,7 @@
         <default>
             <switch>
                 <case
-                    latin:keyboardLayoutSetElement="alphabetManualShifted|alphabetShiftLocked|alphabetShiftLockShifted"
+                    latin:keyboardLayoutSetElement="alphabetManualShifted|alphabetShiftLocked"
                 >
                     <Key
                         latin:keySpec="&quot;"

--- a/app/src/main/res/xml-sw600dp/keys_pcqwerty2_right3.xml
+++ b/app/src/main/res/xml-sw600dp/keys_pcqwerty2_right3.xml
@@ -41,7 +41,7 @@
                 latin:additionalMoreKeys="\\|"
                 latin:keyStyle="hasShiftedLetterHintStyle" />
         </case>
-        <!-- keyboardLayoutSetElement="alphabetManualShifted|alphabetShiftLocked|alphabetShiftLockShifted" -->
+        <!-- keyboardLayoutSetElement="alphabetManualShifted|alphabetShiftLocked" -->
         <default>
             <Key
                 latin:keySpec="{" />

--- a/app/src/main/res/xml-sw600dp/keys_pcqwerty3_right2.xml
+++ b/app/src/main/res/xml-sw600dp/keys_pcqwerty3_right2.xml
@@ -37,7 +37,7 @@
                 latin:keyStyle="hasShiftedLetterHintStyle"
                 latin:moreKeys="!fixedColumnOrder!4,!text/double_quotes,%,!text/single_quotes" />
         </case>
-        <!-- keyboardLayoutSetElement="alphabetManualShifted|alphabetShiftLocked|alphabetShiftLockShifted" -->
+        <!-- keyboardLayoutSetElement="alphabetManualShifted|alphabetShiftLocked" -->
         <default>
             <Key
                 latin:keySpec=":" />

--- a/app/src/main/res/xml-sw600dp/keys_pcqwerty4_right3.xml
+++ b/app/src/main/res/xml-sw600dp/keys_pcqwerty4_right3.xml
@@ -42,7 +42,7 @@
                 latin:keyStyle="hasShiftedLetterHintStyle"
                 latin:moreKeys="!text/morekeys_question" />
         </case>
-        <!-- keyboardLayoutSetElement="alphabetManualShifted|alphabetShiftLocked|alphabetShiftLockShifted" -->
+        <!-- keyboardLayoutSetElement="alphabetManualShifted|alphabetShiftLocked" -->
         <default>
             <!-- U+2039: "‹" SINGLE LEFT-POINTING ANGLE QUOTATION MARK
                  U+203A: "›" SINGLE RIGHT-POINTING ANGLE QUOTATION MARK

--- a/app/src/main/res/xml-sw600dp/rowkeys_pcqwerty1.xml
+++ b/app/src/main/res/xml-sw600dp/rowkeys_pcqwerty1.xml
@@ -109,7 +109,7 @@
                 latin:keyStyle="hasShiftedLetterHintStyle"
                 latin:moreKeys="&#x221E;,&#x2260;,&#x2248;" />
         </case>
-        <!-- keyboardLayoutSetElement="alphabetManualShifted|alphabetShiftLockShifted" -->
+        <!-- keyboardLayoutSetElement="alphabetManualShifted" -->
         <default>
             <include
                  latin:keyboardLayout="@xml/rowkeys_pcqwerty1_shift" />

--- a/app/src/main/res/xml-sw600dp/rows_khmer.xml
+++ b/app/src/main/res/xml-sw600dp/rows_khmer.xml
@@ -53,7 +53,7 @@
             latin:keyWidth="10.0%p" />
         <include latin:keyboardLayout="@xml/rowkeys_khmer4" />
         <switch>
-            <case latin:keyboardLayoutSetElement="alphabetManualShifted|alphabetShiftLocked|alphabetShiftLockShifted">
+            <case latin:keyboardLayoutSetElement="alphabetManualShifted|alphabetShiftLocked">
                 <Spacer />
             </case>
             <default>

--- a/app/src/main/res/xml-sw600dp/rows_lao.xml
+++ b/app/src/main/res/xml-sw600dp/rows_lao.xml
@@ -53,7 +53,7 @@
             latin:keyWidth="10.0%p" />
         <include latin:keyboardLayout="@xml/rowkeys_lao4" />
         <switch>
-            <case latin:keyboardLayoutSetElement="alphabetManualShifted|alphabetShiftLocked|alphabetShiftLockShifted">
+            <case latin:keyboardLayoutSetElement="alphabetManualShifted|alphabetShiftLocked">
                 <Spacer />
             </case>
             <default>

--- a/app/src/main/res/xml-sw600dp/rows_thai.xml
+++ b/app/src/main/res/xml-sw600dp/rows_thai.xml
@@ -58,7 +58,7 @@
             latin:keyWidth="10.0%p" />
         <include latin:keyboardLayout="@xml/rowkeys_thai4" />
         <switch>
-            <case latin:keyboardLayoutSetElement="alphabetManualShifted|alphabetShiftLocked|alphabetShiftLockShifted">
+            <case latin:keyboardLayoutSetElement="alphabetManualShifted|alphabetShiftLocked">
                 <Spacer />
             </case>
             <default>

--- a/app/src/main/res/xml/key_styles_common.xml
+++ b/app/src/main/res/xml/key_styles_common.xml
@@ -23,7 +23,7 @@
 >
     <switch>
         <case
-            latin:keyboardLayoutSetElement="alphabetManualShifted|alphabetShiftLockShifted"
+            latin:keyboardLayoutSetElement="alphabetManualShifted"
         >
             <key-style
                 latin:styleName="hasShiftedLetterHintStyle"
@@ -55,7 +55,7 @@
                 latin:parentStyle="baseForShiftKeyStyle" />
         </case>
         <case
-            latin:keyboardLayoutSetElement="alphabetShiftLocked|alphabetShiftLockShifted"
+            latin:keyboardLayoutSetElement="alphabetShiftLocked"
         >
             <key-style
                 latin:styleName="shiftKeyStyle"

--- a/app/src/main/res/xml/key_styles_enter.xml
+++ b/app/src/main/res/xml/key_styles_enter.xml
@@ -36,7 +36,7 @@
         <!-- Shift + Enter in textMultiLine field. -->
         <case
             latin:isMultiLine="true"
-            latin:keyboardLayoutSetElement="alphabetManualShifted|alphabetShiftLockShifted"
+            latin:keyboardLayoutSetElement="alphabetManualShifted"
         >
             <key-style
                 latin:styleName="enterKeyStyle"

--- a/app/src/main/res/xml/key_thai_kho_khuat.xml
+++ b/app/src/main/res/xml/key_thai_kho_khuat.xml
@@ -23,7 +23,7 @@
 >
     <switch>
         <case
-            latin:keyboardLayoutSetElement="alphabetManualShifted|alphabetShiftLocked|alphabetShiftLockShifted"
+            latin:keyboardLayoutSetElement="alphabetManualShifted|alphabetShiftLocked"
         >
             <!-- U+0E05: "ฅ" THAI CHARACTER KHO KHON -->
             <Key

--- a/app/src/main/res/xml/keyboard_layout_set_bengali_akkhor.xml
+++ b/app/src/main/res/xml/keyboard_layout_set_bengali_akkhor.xml
@@ -37,9 +37,6 @@
         latin:elementKeyboard="@xml/kbd_bengali_akkhor"
         latin:elementName="alphabetShiftLocked" />
     <Element
-        latin:elementKeyboard="@xml/kbd_bengali_akkhor"
-        latin:elementName="alphabetShiftLockShifted" />
-    <Element
         latin:elementKeyboard="@xml/kbd_symbols"
         latin:elementName="symbols" />
     <Element

--- a/app/src/main/res/xml/keyboard_layout_set_georgian.xml
+++ b/app/src/main/res/xml/keyboard_layout_set_georgian.xml
@@ -38,9 +38,6 @@
         latin:elementName="alphabetShiftLocked"
         latin:elementKeyboard="@xml/kbd_georgian" />
     <Element
-        latin:elementName="alphabetShiftLockShifted"
-        latin:elementKeyboard="@xml/kbd_georgian" />
-    <Element
         latin:elementName="symbols"
         latin:elementKeyboard="@xml/kbd_symbols" />
     <Element

--- a/app/src/main/res/xml/keyboard_layout_set_hindi.xml
+++ b/app/src/main/res/xml/keyboard_layout_set_hindi.xml
@@ -38,9 +38,6 @@
         latin:elementName="alphabetShiftLocked"
         latin:elementKeyboard="@xml/kbd_hindi" />
     <Element
-        latin:elementName="alphabetShiftLockShifted"
-        latin:elementKeyboard="@xml/kbd_hindi" />
-    <Element
         latin:elementName="symbols"
         latin:elementKeyboard="@xml/kbd_symbols" />
     <Element

--- a/app/src/main/res/xml/keyboard_layout_set_khmer.xml
+++ b/app/src/main/res/xml/keyboard_layout_set_khmer.xml
@@ -38,9 +38,6 @@
         latin:elementName="alphabetShiftLocked"
         latin:elementKeyboard="@xml/kbd_khmer" />
     <Element
-        latin:elementName="alphabetShiftLockShifted"
-        latin:elementKeyboard="@xml/kbd_khmer" />
-    <Element
         latin:elementName="symbols"
         latin:elementKeyboard="@xml/kbd_symbols" />
     <Element

--- a/app/src/main/res/xml/keyboard_layout_set_lao.xml
+++ b/app/src/main/res/xml/keyboard_layout_set_lao.xml
@@ -38,9 +38,6 @@
         latin:elementName="alphabetShiftLocked"
         latin:elementKeyboard="@xml/kbd_lao" />
     <Element
-        latin:elementName="alphabetShiftLockShifted"
-        latin:elementKeyboard="@xml/kbd_lao" />
-    <Element
         latin:elementName="symbols"
         latin:elementKeyboard="@xml/kbd_symbols" />
     <Element

--- a/app/src/main/res/xml/keyboard_layout_set_nepali_romanized.xml
+++ b/app/src/main/res/xml/keyboard_layout_set_nepali_romanized.xml
@@ -38,9 +38,6 @@
         latin:elementName="alphabetShiftLocked"
         latin:elementKeyboard="@xml/kbd_nepali_romanized" />
     <Element
-        latin:elementName="alphabetShiftLockShifted"
-        latin:elementKeyboard="@xml/kbd_nepali_romanized" />
-    <Element
         latin:elementName="symbols"
         latin:elementKeyboard="@xml/kbd_symbols" />
     <Element

--- a/app/src/main/res/xml/keyboard_layout_set_nepali_traditional.xml
+++ b/app/src/main/res/xml/keyboard_layout_set_nepali_traditional.xml
@@ -38,9 +38,6 @@
         latin:elementName="alphabetShiftLocked"
         latin:elementKeyboard="@xml/kbd_nepali_traditional" />
     <Element
-        latin:elementName="alphabetShiftLockShifted"
-        latin:elementKeyboard="@xml/kbd_nepali_traditional" />
-    <Element
         latin:elementName="symbols"
         latin:elementKeyboard="@xml/kbd_symbols" />
     <Element

--- a/app/src/main/res/xml/keyboard_layout_set_thai.xml
+++ b/app/src/main/res/xml/keyboard_layout_set_thai.xml
@@ -38,9 +38,6 @@
         latin:elementName="alphabetShiftLocked"
         latin:elementKeyboard="@xml/kbd_thai" />
     <Element
-        latin:elementName="alphabetShiftLockShifted"
-        latin:elementKeyboard="@xml/kbd_thai" />
-    <Element
         latin:elementName="symbols"
         latin:elementKeyboard="@xml/kbd_symbols" />
     <Element

--- a/app/src/main/res/xml/keys_dvorak_123.xml
+++ b/app/src/main/res/xml/keys_dvorak_123.xml
@@ -27,7 +27,7 @@
             latin:showExtraChars="true">
             <switch>
                 <case
-                    latin:keyboardLayoutSetElement="alphabetManualShifted|alphabetShiftLocked|alphabetShiftLockShifted"
+                    latin:keyboardLayoutSetElement="alphabetManualShifted|alphabetShiftLocked"
                     >
                     <Key
                         latin:keySpec="&quot;"
@@ -60,7 +60,7 @@
             </switch>
             <switch>
                 <case
-                    latin:keyboardLayoutSetElement="alphabetManualShifted|alphabetShiftLocked|alphabetShiftLockShifted"
+                    latin:keyboardLayoutSetElement="alphabetManualShifted|alphabetShiftLocked"
                     >
                     <Key
                         latin:keySpec="&lt;"
@@ -88,7 +88,7 @@
         <case latin:showNumberRow="true">
             <switch>
                 <case
-                    latin:keyboardLayoutSetElement="alphabetManualShifted|alphabetShiftLocked|alphabetShiftLockShifted"
+                    latin:keyboardLayoutSetElement="alphabetManualShifted|alphabetShiftLocked"
                     >
                     <Key
                         latin:keySpec="&quot;" />
@@ -113,7 +113,7 @@
             </switch>
             <switch>
                 <case
-                    latin:keyboardLayoutSetElement="alphabetManualShifted|alphabetShiftLocked|alphabetShiftLockShifted"
+                    latin:keyboardLayoutSetElement="alphabetManualShifted|alphabetShiftLocked"
                     >
                     <Key
                         latin:keySpec="&lt;" />
@@ -133,7 +133,7 @@
         <default>
             <switch>
                 <case
-                    latin:keyboardLayoutSetElement="alphabetManualShifted|alphabetShiftLocked|alphabetShiftLockShifted"
+                    latin:keyboardLayoutSetElement="alphabetManualShifted|alphabetShiftLocked"
                 >
                     <Key
                         latin:keySpec="&quot;"
@@ -166,7 +166,7 @@
             </switch>
             <switch>
                 <case
-                    latin:keyboardLayoutSetElement="alphabetManualShifted|alphabetShiftLocked|alphabetShiftLockShifted"
+                    latin:keyboardLayoutSetElement="alphabetManualShifted|alphabetShiftLocked"
                 >
                     <Key
                         latin:keySpec="&lt;"

--- a/app/src/main/res/xml/keys_pcqwerty2_right3.xml
+++ b/app/src/main/res/xml/keys_pcqwerty2_right3.xml
@@ -35,7 +35,7 @@
                 latin:keySpec="\\"
                 latin:additionalMoreKeys="\\|" />
         </case>
-        <!-- keyboardLayoutSetElement="alphabetManualShifted|alphabetShiftLocked|alphabetShiftLockShifted" -->
+        <!-- keyboardLayoutSetElement="alphabetManualShifted|alphabetShiftLocked" -->
         <default>
             <Key
                 latin:keySpec="{" />

--- a/app/src/main/res/xml/keys_pcqwerty3_right2.xml
+++ b/app/src/main/res/xml/keys_pcqwerty3_right2.xml
@@ -33,7 +33,7 @@
                 latin:additionalMoreKeys="&quot;"
                 latin:moreKeys="!fixedColumnOrder!4,!text/double_quotes,%,!text/single_quotes" />
         </case>
-        <!-- keyboardLayoutSetElement="alphabetManualShifted|alphabetShiftLocked|alphabetShiftLockShifted" -->
+        <!-- keyboardLayoutSetElement="alphabetManualShifted|alphabetShiftLocked" -->
         <default>
             <Key
                 latin:keySpec=":" />

--- a/app/src/main/res/xml/keys_pcqwerty4_right3.xml
+++ b/app/src/main/res/xml/keys_pcqwerty4_right3.xml
@@ -36,7 +36,7 @@
                 latin:additionalMoreKeys="\?"
                 latin:moreKeys="!text/morekeys_question" />
         </case>
-        <!-- keyboardLayoutSetElement="alphabetManualShifted|alphabetShiftLocked|alphabetShiftLockShifted" -->
+        <!-- keyboardLayoutSetElement="alphabetManualShifted|alphabetShiftLocked" -->
         <default>
             <!-- U+2039: "‹" SINGLE LEFT-POINTING ANGLE QUOTATION MARK
                  U+203A: "›" SINGLE RIGHT-POINTING ANGLE QUOTATION MARK

--- a/app/src/main/res/xml/rowkeys_azerty3.xml
+++ b/app/src/main/res/xml/rowkeys_azerty3.xml
@@ -73,7 +73,7 @@
     </switch>
     <switch>
         <case
-            latin:keyboardLayoutSetElement="alphabetManualShifted|alphabetShiftLockShifted"
+            latin:keyboardLayoutSetElement="alphabetManualShifted"
         >
             <Key
                 latin:keySpec="\?" />

--- a/app/src/main/res/xml/rowkeys_bengali_akkhor1.xml
+++ b/app/src/main/res/xml/rowkeys_bengali_akkhor1.xml
@@ -20,7 +20,7 @@
 
 <merge xmlns:latin="http://schemas.android.com/apk/res-auto">
     <switch>
-        <case latin:keyboardLayoutSetElement="alphabetManualShifted|alphabetShiftLocked|alphabetShiftLockShifted">
+        <case latin:keyboardLayoutSetElement="alphabetManualShifted|alphabetShiftLocked">
             <!-- U+09A2: "ঢ" BENGALI LETTER DDHA -->
             <Key latin:keySpec="&#x09A2;" />
             <!-- U+09A0: "ঠ" BENGALI LETTER TTHA -->

--- a/app/src/main/res/xml/rowkeys_bengali_akkhor2.xml
+++ b/app/src/main/res/xml/rowkeys_bengali_akkhor2.xml
@@ -20,7 +20,7 @@
 
 <merge xmlns:latin="http://schemas.android.com/apk/res-auto">
     <switch>
-        <case latin:keyboardLayoutSetElement="alphabetManualShifted|alphabetShiftLocked|alphabetShiftLockShifted">
+        <case latin:keyboardLayoutSetElement="alphabetManualShifted|alphabetShiftLocked">
             <!-- U+0985: "অ" BENGALI LETTER A -->
             <Key latin:keySpec="&#x0985;" />
             <!-- U+09B6: "শ" BENGALI LETTER SHA

--- a/app/src/main/res/xml/rowkeys_bengali_akkhor3.xml
+++ b/app/src/main/res/xml/rowkeys_bengali_akkhor3.xml
@@ -20,7 +20,7 @@
 
 <merge xmlns:latin="http://schemas.android.com/apk/res-auto">
     <switch>
-        <case latin:keyboardLayoutSetElement="alphabetManualShifted|alphabetShiftLocked|alphabetShiftLockShifted">
+        <case latin:keyboardLayoutSetElement="alphabetManualShifted|alphabetShiftLocked">
             <!-- U+0964: "।" DEVANAGARI DANDA
                  U+0965: "॥" DEVANAGARI DOUBLE DANDA -->
             <Key

--- a/app/src/main/res/xml/rowkeys_colemak1.xml
+++ b/app/src/main/res/xml/rowkeys_colemak1.xml
@@ -69,7 +69,7 @@
                 latin:moreKeys="!text/morekeys_y" />
             <switch>
                 <case
-                    latin:keyboardLayoutSetElement="alphabetManualShifted|alphabetShiftLockShifted"
+                    latin:keyboardLayoutSetElement="alphabetManualShifted"
                     >
                     <Key
                         latin:keySpec=":"
@@ -111,7 +111,7 @@
                 latin:moreKeys="!text/morekeys_y" />
             <switch>
                 <case
-                    latin:keyboardLayoutSetElement="alphabetManualShifted|alphabetShiftLockShifted"
+                    latin:keyboardLayoutSetElement="alphabetManualShifted"
                 >
                     <Key
                         latin:keySpec=":" />
@@ -167,7 +167,7 @@
                 latin:moreKeys="!text/morekeys_y" />
             <switch>
                 <case
-                    latin:keyboardLayoutSetElement="alphabetManualShifted|alphabetShiftLockShifted"
+                    latin:keyboardLayoutSetElement="alphabetManualShifted"
                     >
                     <Key
                         latin:keySpec=":"

--- a/app/src/main/res/xml/rowkeys_georgian1.xml
+++ b/app/src/main/res/xml/rowkeys_georgian1.xml
@@ -25,7 +25,7 @@
         <case latin:showNumberRow="true">
             <switch>
                 <case
-                    latin:keyboardLayoutSetElement="alphabetManualShifted|alphabetShiftLocked|alphabetShiftLockShifted"
+                    latin:keyboardLayoutSetElement="alphabetManualShifted|alphabetShiftLocked"
                 >
                     <Key
                         latin:keySpec="Q" />
@@ -94,7 +94,7 @@
         <default>
             <switch>
                 <case
-                    latin:keyboardLayoutSetElement="alphabetManualShifted|alphabetShiftLocked|alphabetShiftLockShifted"
+                    latin:keyboardLayoutSetElement="alphabetManualShifted|alphabetShiftLocked"
                     >
                     <Key
                         latin:keySpec="Q"

--- a/app/src/main/res/xml/rowkeys_georgian2.xml
+++ b/app/src/main/res/xml/rowkeys_georgian2.xml
@@ -23,7 +23,7 @@
 >
     <switch>
         <case
-            latin:keyboardLayoutSetElement="alphabetManualShifted|alphabetShiftLocked|alphabetShiftLockShifted"
+            latin:keyboardLayoutSetElement="alphabetManualShifted|alphabetShiftLocked"
         >
             <Key
                 latin:keySpec="A" />

--- a/app/src/main/res/xml/rowkeys_georgian3.xml
+++ b/app/src/main/res/xml/rowkeys_georgian3.xml
@@ -23,7 +23,7 @@
 >
     <switch>
         <case
-            latin:keyboardLayoutSetElement="alphabetManualShifted|alphabetShiftLocked|alphabetShiftLockShifted"
+            latin:keyboardLayoutSetElement="alphabetManualShifted"
         >
             <!-- U+10EB: "ძ" GEORGIAN LETTER JIL -->
             <Key

--- a/app/src/main/res/xml/rowkeys_greek1.xml
+++ b/app/src/main/res/xml/rowkeys_greek1.xml
@@ -27,7 +27,7 @@
             latin:showExtraChars="true">
             <switch>
                 <case
-                    latin:keyboardLayoutSetElement="alphabetManualShifted|alphabetShiftLockShifted"
+                    latin:keyboardLayoutSetElement="alphabetManualShifted"
                     >
                     <Key
                         latin:keySpec=":"
@@ -45,7 +45,7 @@
             <!--
             <switch>
                 <case
-                    latin:keyboardLayoutSetElement="alphabetManualShifted|alphabetShiftLockShifted"
+                    latin:keyboardLayoutSetElement="alphabetManualShifted"
                 >
                     U+0385: "΅" GREEK DIALYTIKA TONOS
                     <Key
@@ -122,7 +122,7 @@
         <case latin:showNumberRow="true">
             <switch>
                 <case
-                    latin:keyboardLayoutSetElement="alphabetManualShifted|alphabetShiftLockShifted"
+                    latin:keyboardLayoutSetElement="alphabetManualShifted"
                 >
                     <Key
                         latin:keySpec=":" />
@@ -136,7 +136,7 @@
             <!--
             <switch>
                 <case
-                    latin:keyboardLayoutSetElement="alphabetManualShifted|alphabetShiftLockShifted"
+                    latin:keyboardLayoutSetElement="alphabetManualShifted"
                 >
                     U+0385: "΅" GREEK DIALYTIKA TONOS
                     <Key
@@ -194,7 +194,7 @@
         <default>
             <switch>
                 <case
-                    latin:keyboardLayoutSetElement="alphabetManualShifted|alphabetShiftLockShifted"
+                    latin:keyboardLayoutSetElement="alphabetManualShifted"
                     >
                     <Key
                         latin:keySpec=":"
@@ -214,7 +214,7 @@
             <!--
             <switch>
                 <case
-                    latin:keyboardLayoutSetElement="alphabetManualShifted|alphabetShiftLockShifted"
+                    latin:keyboardLayoutSetElement="alphabetManualShifted"
                 >
                     U+0385: "΅" GREEK DIALYTIKA TONOS
                     <Key

--- a/app/src/main/res/xml/rowkeys_hindi1.xml
+++ b/app/src/main/res/xml/rowkeys_hindi1.xml
@@ -20,7 +20,7 @@
 
 <merge xmlns:latin="http://schemas.android.com/apk/res-auto">
     <switch>
-        <case latin:keyboardLayoutSetElement="alphabetManualShifted|alphabetShiftLocked|alphabetShiftLockShifted">
+        <case latin:keyboardLayoutSetElement="alphabetManualShifted|alphabetShiftLocked">
             <!-- U+0914: "औ" DEVANAGARI LETTER AU
                  U+0912/U+0902: "ऒं" DEVANAGARI LETTER SHORT O//DEVANAGARI SIGN ANUSVARA -->
             <Key

--- a/app/src/main/res/xml/rowkeys_hindi2.xml
+++ b/app/src/main/res/xml/rowkeys_hindi2.xml
@@ -20,7 +20,7 @@
 
 <merge xmlns:latin="http://schemas.android.com/apk/res-auto">
     <switch>
-        <case latin:keyboardLayoutSetElement="alphabetManualShifted|alphabetShiftLocked|alphabetShiftLockShifted">
+        <case latin:keyboardLayoutSetElement="alphabetManualShifted|alphabetShiftLocked">
             <!-- U+0913: "ओ" DEVANAGARI LETTER O
                  U+0913/U+0902: "ओं" DEVANAGARI LETTER O/DEVANAGARI SIGN ANUSVARA
                  U+0911: "ऑ" DEVANAGARI LETTER CANDRA O

--- a/app/src/main/res/xml/rowkeys_hindi3.xml
+++ b/app/src/main/res/xml/rowkeys_hindi3.xml
@@ -20,7 +20,7 @@
 
 <merge xmlns:latin="http://schemas.android.com/apk/res-auto">
     <switch>
-        <case latin:keyboardLayoutSetElement="alphabetManualShifted|alphabetShiftLocked|alphabetShiftLockShifted">
+        <case latin:keyboardLayoutSetElement="alphabetManualShifted|alphabetShiftLocked">
             <!-- U+0911: "ऑ" DEVANAGARI LETTER CANDRA O -->
             <Key latin:keySpec="&#x0911;" />
             <!-- Because the font rendering system prior to API version 16 can't automatically

--- a/app/src/main/res/xml/rowkeys_khmer1.xml
+++ b/app/src/main/res/xml/rowkeys_khmer1.xml
@@ -20,7 +20,7 @@
 
 <merge xmlns:latin="http://schemas.android.com/apk/res-auto">
     <switch>
-        <case latin:keyboardLayoutSetElement="alphabetManualShifted|alphabetShiftLocked|alphabetShiftLockShifted">
+        <case latin:keyboardLayoutSetElement="alphabetManualShifted|alphabetShiftLocked">
             <!-- U+200D: ZERO WIDTH JOINER -->
             <Key
                 latin:keySpec="!"

--- a/app/src/main/res/xml/rowkeys_khmer2.xml
+++ b/app/src/main/res/xml/rowkeys_khmer2.xml
@@ -20,7 +20,7 @@
 
 <merge xmlns:latin="http://schemas.android.com/apk/res-auto">
     <switch>
-        <case latin:keyboardLayoutSetElement="alphabetManualShifted|alphabetShiftLocked|alphabetShiftLockShifted">
+        <case latin:keyboardLayoutSetElement="alphabetManualShifted|alphabetShiftLocked">
             <!-- U+1788: "ឈ" KHMER LETTER CHO
                  U+17DC: "ៜ" KHMER SIGN AVAKRAHASANYA -->
             <Key

--- a/app/src/main/res/xml/rowkeys_khmer3.xml
+++ b/app/src/main/res/xml/rowkeys_khmer3.xml
@@ -20,7 +20,7 @@
 
 <merge xmlns:latin="http://schemas.android.com/apk/res-auto">
     <switch>
-        <case latin:keyboardLayoutSetElement="alphabetManualShifted|alphabetShiftLocked|alphabetShiftLockShifted">
+        <case latin:keyboardLayoutSetElement="alphabetManualShifted|alphabetShiftLocked">
             <!-- U+17B6/U+17C6: "ាំ" KHMER VOWEL SIGN AA/KHMER SIGN NIKAHIT -->
             <Key
                 latin:keySpec="&#x17B6;&#x17C6;"

--- a/app/src/main/res/xml/rowkeys_khmer4.xml
+++ b/app/src/main/res/xml/rowkeys_khmer4.xml
@@ -20,7 +20,7 @@
 
 <merge xmlns:latin="http://schemas.android.com/apk/res-auto">
     <switch>
-        <case latin:keyboardLayoutSetElement="alphabetManualShifted|alphabetShiftLocked|alphabetShiftLockShifted">
+        <case latin:keyboardLayoutSetElement="alphabetManualShifted|alphabetShiftLocked">
             <!-- U+178D: "ឍ" KHMER LETTER TTHO -->
             <Key latin:keySpec="&#x178D;" />
             <!-- U+1783: "ឃ" KHMER LETTER KHO -->

--- a/app/src/main/res/xml/rowkeys_lao1.xml
+++ b/app/src/main/res/xml/rowkeys_lao1.xml
@@ -20,7 +20,7 @@
 
 <merge xmlns:latin="http://schemas.android.com/apk/res-auto">
     <switch>
-        <case latin:keyboardLayoutSetElement="alphabetManualShifted|alphabetShiftLocked|alphabetShiftLockShifted">
+        <case latin:keyboardLayoutSetElement="alphabetManualShifted|alphabetShiftLocked">
             <!-- U+0ED1: "໑" LAO DIGIT ONE -->
             <Key latin:keySpec="&#x0ED1;" />
             <!-- U+0ED2: "໒" LAO DIGIT TWO -->

--- a/app/src/main/res/xml/rowkeys_lao2.xml
+++ b/app/src/main/res/xml/rowkeys_lao2.xml
@@ -20,7 +20,7 @@
 
 <merge xmlns:latin="http://schemas.android.com/apk/res-auto">
     <switch>
-        <case latin:keyboardLayoutSetElement="alphabetManualShifted|alphabetShiftLocked|alphabetShiftLockShifted">
+        <case latin:keyboardLayoutSetElement="alphabetManualShifted|alphabetShiftLocked">
             <!-- U+0EBB/U+0EC9: "" LAO VOWEL SIGN MAI KON/LAO TONE MAI THO -->
             <Key
                 latin:keySpec="&#x0EBB;&#x0EC9;"

--- a/app/src/main/res/xml/rowkeys_lao3.xml
+++ b/app/src/main/res/xml/rowkeys_lao3.xml
@@ -20,7 +20,7 @@
 
 <merge xmlns:latin="http://schemas.android.com/apk/res-auto">
     <switch>
-        <case latin:keyboardLayoutSetElement="alphabetManualShifted|alphabetShiftLocked|alphabetShiftLockShifted">
+        <case latin:keyboardLayoutSetElement="alphabetManualShifted|alphabetShiftLocked">
             <!-- U+0EB1/U+0EC9: "ັ້" LAO VOWEL SIGN MAI KAN/LAO TONE MAI THO -->
             <Key
                 latin:keySpec="&#x0EB1;&#x0EC9;"

--- a/app/src/main/res/xml/rowkeys_lao4.xml
+++ b/app/src/main/res/xml/rowkeys_lao4.xml
@@ -20,7 +20,7 @@
 
 <merge xmlns:latin="http://schemas.android.com/apk/res-auto">
     <switch>
-        <case latin:keyboardLayoutSetElement="alphabetManualShifted|alphabetShiftLocked|alphabetShiftLockShifted">
+        <case latin:keyboardLayoutSetElement="alphabetManualShifted|alphabetShiftLocked">
             <!-- U+20AD: "₭" KIP SIGN -->
             <Key
                 latin:keySpec="&#x20AD;"

--- a/app/src/main/res/xml/rowkeys_nepali_romanized1.xml
+++ b/app/src/main/res/xml/rowkeys_nepali_romanized1.xml
@@ -20,7 +20,7 @@
 
 <merge xmlns:latin="http://schemas.android.com/apk/res-auto">
     <switch>
-        <case latin:keyboardLayoutSetElement="alphabetManualShifted|alphabetShiftLocked|alphabetShiftLockShifted">
+        <case latin:keyboardLayoutSetElement="alphabetManualShifted|alphabetShiftLocked">
             <!-- U+0920: "ठ" DEVANAGARI LETTER TTHA -->
             <Key latin:keySpec="&#x0920;" />
             <!-- U+0914: "औ" DEVANAGARI LETTER AU -->

--- a/app/src/main/res/xml/rowkeys_nepali_romanized2.xml
+++ b/app/src/main/res/xml/rowkeys_nepali_romanized2.xml
@@ -20,7 +20,7 @@
 
 <merge xmlns:latin="http://schemas.android.com/apk/res-auto">
     <switch>
-        <case latin:keyboardLayoutSetElement="alphabetManualShifted|alphabetShiftLocked|alphabetShiftLockShifted">
+        <case latin:keyboardLayoutSetElement="alphabetManualShifted|alphabetShiftLocked">
             <!-- U+0906: "आ" DEVANAGARI LETTER AA -->
             <Key latin:keySpec="&#x0906;" />
             <!-- U+0936: "श" DEVANAGARI LETTER SHA -->

--- a/app/src/main/res/xml/rowkeys_nepali_romanized3.xml
+++ b/app/src/main/res/xml/rowkeys_nepali_romanized3.xml
@@ -20,7 +20,7 @@
 
 <merge xmlns:latin="http://schemas.android.com/apk/res-auto">
     <switch>
-        <case latin:keyboardLayoutSetElement="alphabetManualShifted|alphabetShiftLocked|alphabetShiftLockShifted">
+        <case latin:keyboardLayoutSetElement="alphabetManualShifted|alphabetShiftLocked">
             <!-- U+090B: "ऋ" DEVANAGARI LETTER VOCALIC R -->
             <Key latin:keySpec="&#x090B;" />
             <!-- U+0922: "ढ" DEVANAGARI LETTER DDHA -->

--- a/app/src/main/res/xml/rowkeys_nepali_traditional1.xml
+++ b/app/src/main/res/xml/rowkeys_nepali_traditional1.xml
@@ -20,7 +20,7 @@
 
 <merge xmlns:latin="http://schemas.android.com/apk/res-auto">
     <switch>
-        <case latin:keyboardLayoutSetElement="alphabetManualShifted|alphabetShiftLocked|alphabetShiftLockShifted">
+        <case latin:keyboardLayoutSetElement="alphabetManualShifted|alphabetShiftLocked">
             <!-- U+0924/U+094D/U+0924: "त्त" DEVANAGARI LETTER TA/DEVANAGARI SIGN VIRAMA/DEVANAGARI LETTER TA
                  U+091E: "ञ" DEVANAGARI LETTER NYA
                  U+091C/U+094D/U+091E: "ज्ञ" DEVANAGARI LETTER JA/DEVANAGARI SIGN VIRAMA/DEVANAGARI LETTER NYA

--- a/app/src/main/res/xml/rowkeys_nepali_traditional2.xml
+++ b/app/src/main/res/xml/rowkeys_nepali_traditional2.xml
@@ -20,7 +20,7 @@
 
 <merge xmlns:latin="http://schemas.android.com/apk/res-auto">
     <switch>
-        <case latin:keyboardLayoutSetElement="alphabetManualShifted|alphabetShiftLocked|alphabetShiftLockShifted">
+        <case latin:keyboardLayoutSetElement="alphabetManualShifted|alphabetShiftLocked">
             <!-- U+0906: "आ" DEVANAGARI LETTER AA -->
             <Key latin:keySpec="&#x0906;" />
             <!-- U+0919/U+094D: "ङ्" DEVANAGARI LETTER NGA/DEVANAGARI SIGN VIRAMA -->

--- a/app/src/main/res/xml/rowkeys_nepali_traditional3.xml
+++ b/app/src/main/res/xml/rowkeys_nepali_traditional3.xml
@@ -20,7 +20,7 @@
 
 <merge xmlns:latin="http://schemas.android.com/apk/res-auto">
     <switch>
-        <case latin:keyboardLayoutSetElement="alphabetManualShifted|alphabetShiftLocked|alphabetShiftLockShifted">
+        <case latin:keyboardLayoutSetElement="alphabetManualShifted|alphabetShiftLocked">
             <!-- U+0915/U+094D: "क्" DEVANAGARI LETTER KA/DEVANAGARI SIGN VIRAMA -->
             <Key
                 latin:keySpec="&#x0915;&#x094D;"

--- a/app/src/main/res/xml/rowkeys_pcqwerty1.xml
+++ b/app/src/main/res/xml/rowkeys_pcqwerty1.xml
@@ -83,7 +83,7 @@
                 latin:additionalMoreKeys="+"
                 latin:moreKeys="!fixedColumnOrder!4,&#x221E;,&#x2260;,&#x2248;,%" />
         </case>
-        <!-- keyboardLayoutSetElement="alphabetManualShifted|alphabetShiftLockShifted" -->
+        <!-- keyboardLayoutSetElement="alphabetManualShifted" -->
         <default>
             <include
                  latin:keyboardLayout="@xml/rowkeys_pcqwerty1_shift" />

--- a/app/src/main/res/xml/rowkeys_thai1.xml
+++ b/app/src/main/res/xml/rowkeys_thai1.xml
@@ -20,7 +20,7 @@
 
 <merge xmlns:latin="http://schemas.android.com/apk/res-auto">
     <switch>
-        <case latin:keyboardLayoutSetElement="alphabetManualShifted|alphabetShiftLocked|alphabetShiftLockShifted">
+        <case latin:keyboardLayoutSetElement="alphabetManualShifted|alphabetShiftLocked">
             <Key
                 latin:keySpec="+"
                 latin:keyLabelFlags="fontDefault" />

--- a/app/src/main/res/xml/rowkeys_thai2.xml
+++ b/app/src/main/res/xml/rowkeys_thai2.xml
@@ -20,7 +20,7 @@
 
 <merge xmlns:latin="http://schemas.android.com/apk/res-auto">
     <switch>
-        <case latin:keyboardLayoutSetElement="alphabetManualShifted|alphabetShiftLocked|alphabetShiftLockShifted">
+        <case latin:keyboardLayoutSetElement="alphabetManualShifted|alphabetShiftLocked">
             <!-- U+0E50: "๐" THAI DIGIT ZERO -->
             <Key latin:keySpec="&#x0E50;" />
             <Key

--- a/app/src/main/res/xml/rowkeys_thai3.xml
+++ b/app/src/main/res/xml/rowkeys_thai3.xml
@@ -20,7 +20,7 @@
 
 <merge xmlns:latin="http://schemas.android.com/apk/res-auto">
     <switch>
-        <case latin:keyboardLayoutSetElement="alphabetManualShifted|alphabetShiftLocked|alphabetShiftLockShifted">
+        <case latin:keyboardLayoutSetElement="alphabetManualShifted|alphabetShiftLocked">
             <!-- U+0E24: "ฤ" THAI CHARACTER RU -->
             <Key latin:keySpec="&#x0E24;" />
             <!-- U+0E06: "ฆ" THAI CHARACTER KHO RAKHANG -->

--- a/app/src/main/res/xml/rowkeys_thai4.xml
+++ b/app/src/main/res/xml/rowkeys_thai4.xml
@@ -20,7 +20,7 @@
 
 <merge xmlns:latin="http://schemas.android.com/apk/res-auto">
     <switch>
-        <case latin:keyboardLayoutSetElement="alphabetManualShifted|alphabetShiftLocked|alphabetShiftLockShifted">
+        <case latin:keyboardLayoutSetElement="alphabetManualShifted|alphabetShiftLocked">
             <Key
                 latin:keySpec="("
                 latin:keyLabelFlags="fontDefault" />

--- a/app/src/main/res/xml/rowkeys_urdu1.xml
+++ b/app/src/main/res/xml/rowkeys_urdu1.xml
@@ -20,7 +20,7 @@
 
 <merge xmlns:latin="http://schemas.android.com/apk/res-auto">
     <switch>
-        <case latin:keyboardLayoutSetElement="alphabetManualShifted|alphabetShiftLocked|alphabetShiftLockShifted">
+        <case latin:keyboardLayoutSetElement="alphabetManualShifted|alphabetShiftLocked">
             <!-- U+0654: "ٔ" ARABIC HAMZA ABOVE -->
             <Key latin:keySpec="&#x0654;" />
             <!-- U+0652: "ْ" ARABIC SUKUN -->

--- a/app/src/main/res/xml/rowkeys_urdu2.xml
+++ b/app/src/main/res/xml/rowkeys_urdu2.xml
@@ -20,7 +20,7 @@
 
 <merge xmlns:latin="http://schemas.android.com/apk/res-auto">
     <switch>
-        <case latin:keyboardLayoutSetElement="alphabetManualShifted|alphabetShiftLocked|alphabetShiftLockShifted">
+        <case latin:keyboardLayoutSetElement="alphabetManualShifted|alphabetShiftLocked">
             <!-- U+060F: "؏" ARABIC SIGN MISRA -->
             <Key latin:keySpec="&#x060F;" />
             <!-- U+060E: "؎" ARABIC POETIC VERSE SIGN -->

--- a/app/src/main/res/xml/rowkeys_urdu3.xml
+++ b/app/src/main/res/xml/rowkeys_urdu3.xml
@@ -20,7 +20,7 @@
 
 <merge xmlns:latin="http://schemas.android.com/apk/res-auto">
     <switch>
-        <case latin:keyboardLayoutSetElement="alphabetManualShifted|alphabetShiftLocked|alphabetShiftLockShifted">
+        <case latin:keyboardLayoutSetElement="alphabetManualShifted|alphabetShiftLocked">
             <!-- U+0601: "؁" ARABIC SIGN SANAH -->
             <Key latin:keySpec="&#x0601;" />
             <!-- U+0600: "" ARABIC NUMBER SIGN -->


### PR DESCRIPTION
@wittmane this is regarding the issue of _123 -> !@# -> 123_.

I have found two places where this reproduces in original AZERTY layout:
1. Clicking shift in auto-capitalization state (first letter in sentence)
2. Clicking shift in shift-locked state (long-press shift to lock, then click shift)

First seems to be resolvable by checking `prevShiftMode != AUTOMATIC_SHIFT` on shift click to not set a new layout until shift is released.
Second is mysterious. It seems that a specific "while shift is clicked after shift locked" state was made. It seems to be useless as visually it only goes into "manually unshifted" mode on shift release. I don't see why a layout would need to change while shift is being clicked in that state.

I have removed the `alphabetShiftLockShifted` state and so far it seems to work consistently with GBoard. I have made this in PR as it feels that there was some porpoise to all this that I haven't found yet. I'll test this for a while before merging.