### PR TITLE
Don't mark the keyboard as manual shifted while pressing the shift key when it is already auto-shifted

### DIFF
--- a/app/src/main/java/rkr/simplekeyboard/inputmethod/keyboard/internal/AlphabetShiftState.java
+++ b/app/src/main/java/rkr/simplekeyboard/inputmethod/keyboard/internal/AlphabetShiftState.java
@@ -24,10 +24,9 @@ public final class AlphabetShiftState {
 
     private static final int UNSHIFTED = 0;
     private static final int MANUAL_SHIFTED = 1;
-    private static final int MANUAL_SHIFTED_FROM_AUTO = 2;
-    private static final int AUTOMATIC_SHIFTED = 3;
-    private static final int SHIFT_LOCKED = 4;
-    private static final int SHIFT_LOCK_SHIFTED = 5;
+    private static final int AUTOMATIC_SHIFTED = 2;
+    private static final int SHIFT_LOCKED = 3;
+    private static final int SHIFT_LOCK_SHIFTED = 4;
 
     private int mState = UNSHIFTED;
 
@@ -38,9 +37,6 @@ public final class AlphabetShiftState {
             case UNSHIFTED:
                 mState = MANUAL_SHIFTED;
                 break;
-            case AUTOMATIC_SHIFTED:
-                mState = MANUAL_SHIFTED_FROM_AUTO;
-                break;
             case SHIFT_LOCKED:
                 mState = SHIFT_LOCK_SHIFTED;
                 break;
@@ -48,7 +44,6 @@ public final class AlphabetShiftState {
         } else {
             switch (oldState) {
             case MANUAL_SHIFTED:
-            case MANUAL_SHIFTED_FROM_AUTO:
             case AUTOMATIC_SHIFTED:
                 mState = UNSHIFTED;
                 break;
@@ -67,7 +62,6 @@ public final class AlphabetShiftState {
             switch (oldState) {
             case UNSHIFTED:
             case MANUAL_SHIFTED:
-            case MANUAL_SHIFTED_FROM_AUTO:
             case AUTOMATIC_SHIFTED:
                 mState = SHIFT_LOCKED;
                 break;
@@ -101,12 +95,7 @@ public final class AlphabetShiftState {
     }
 
     public boolean isManualShifted() {
-        return mState == MANUAL_SHIFTED || mState == MANUAL_SHIFTED_FROM_AUTO
-                || mState == SHIFT_LOCK_SHIFTED;
-    }
-
-    public boolean isManualShiftedFromAutomaticShifted() {
-        return mState == MANUAL_SHIFTED_FROM_AUTO;
+        return mState == MANUAL_SHIFTED || mState == SHIFT_LOCK_SHIFTED;
     }
 
     @Override
@@ -118,7 +107,6 @@ public final class AlphabetShiftState {
         switch (state) {
         case UNSHIFTED: return "UNSHIFTED";
         case MANUAL_SHIFTED: return "MANUAL_SHIFTED";
-        case MANUAL_SHIFTED_FROM_AUTO: return "MANUAL_SHIFTED_FROM_AUTO";
         case AUTOMATIC_SHIFTED: return "AUTOMATIC_SHIFTED";
         case SHIFT_LOCKED: return "SHIFT_LOCKED";
         case SHIFT_LOCK_SHIFTED: return "SHIFT_LOCK_SHIFTED";

--- a/app/src/main/java/rkr/simplekeyboard/inputmethod/keyboard/internal/KeyboardState.java
+++ b/app/src/main/java/rkr/simplekeyboard/inputmethod/keyboard/internal/KeyboardState.java
@@ -354,7 +354,8 @@ public final class KeyboardState {
             // shifted mode.
             if (!isSinglePointer && mIsAlphabetMode
                     && autoCapsFlags != TextUtils.CAP_MODE_CHARACTERS) {
-                final boolean needsToResetAutoCaps = mAlphabetShiftState.isAutomaticShifted()
+                final boolean needsToResetAutoCaps =
+                        (mAlphabetShiftState.isAutomaticShifted() && !mShiftKeyState.isChording())
                         || (mAlphabetShiftState.isManualShifted() && mShiftKeyState.isReleasing());
                 if (needsToResetAutoCaps) {
                     mSwitchActions.setAlphabetKeyboard();
@@ -486,9 +487,8 @@ public final class KeyboardState {
                     setShifted(SHIFT_LOCK_SHIFTED);
                     mShiftKeyState.onPress();
                 } else if (mAlphabetShiftState.isAutomaticShifted()) {
-                    // Shift key is pressed while automatic shifted, we have to move to manual
-                    // shifted.
-                    setShifted(MANUAL_SHIFT);
+                    // Shift key pressed while automatic shifted isn't considered a manual shift
+                    // since it doesn't change the keyboard into a shifted state.
                     mShiftKeyState.onPress();
                 } else if (mAlphabetShiftState.isShiftedOrShiftLocked()) {
                     // In manual shifted state, we just record shift key has been pressing while
@@ -552,10 +552,9 @@ public final class KeyboardState {
                 // Shift has been pressed without chording while shifted state.
                 setShifted(UNSHIFT);
                 mIsInAlphabetUnshiftedFromShifted = true;
-            } else if (mAlphabetShiftState.isManualShiftedFromAutomaticShifted()
-                    && mShiftKeyState.isPressing() && !withSliding) {
-                // Shift has been pressed without chording while manual shifted transited from
-                // automatic shifted
+            } else if (mAlphabetShiftState.isAutomaticShifted() && mShiftKeyState.isPressing()
+                    && !withSliding) {
+                // Shift has been pressed without chording while automatic shifted
                 setShifted(UNSHIFT);
                 mIsInAlphabetUnshiftedFromShifted = true;
             }


### PR DESCRIPTION
You beat me to making a PR. This is the solution I came up with before seeing yours. The main difference is that I'm removing the `MANUAL_SHIFTED_FROM_AUTO` state. Basically, now it doesn't change to a manual shifted state internally when pressing the shift key on when it was already auto-shifted. It does seem a little weird that there are checks for the shift key state being pressing/chording on an auto-shift state, but I think that's better than internally saying that the state is manual shifted, but not actually update the keyboard to the manual shifted state. Assuming you agree, you might want to remove the `&& prevShiftMode != AUTOMATIC_SHIFT` change that you made in `setShifted`, as I don't think that's necessary. I'm requesting to add this to the branch for your PR since you're already making the fix and the change I'm suggesting is a bit more risky, so if you're already going to sit on it for a while for testing, it's not a bad idea to get a bit of extra validation. I could move this to be a PR to master if you prefer.