### PR TITLE
Allow auto-caps to work after sliding from shift

### DIFF
--- a/app/src/main/java/rkr/simplekeyboard/inputmethod/keyboard/internal/KeyboardState.java
+++ b/app/src/main/java/rkr/simplekeyboard/inputmethod/keyboard/internal/KeyboardState.java
@@ -77,7 +77,6 @@ public final class KeyboardState {
     private static final int SWITCH_STATE_SYMBOL = 2;
     private static final int SWITCH_STATE_MOMENTARY_ALPHA_AND_SYMBOL = 3;
     private static final int SWITCH_STATE_MOMENTARY_SYMBOL_AND_MORE = 4;
-    private static final int SWITCH_STATE_MOMENTARY_ALPHA_SHIFT = 5;
     private int mSwitchState = SWITCH_STATE_ALPHA;
 
     private boolean mIsAlphabetMode;
@@ -534,12 +533,6 @@ public final class KeyboardState {
                 mShiftKeyState.onRelease();
                 mSwitchActions.requestUpdatingShiftState(autoCapsFlags, recapitalizeMode);
                 return;
-            } else if (mAlphabetShiftState.isShiftLockShifted() && withSliding) {
-                // In shift locked state, shift has been pressed and slid out to other key.
-                setShiftLocked(true);
-            } else if (mAlphabetShiftState.isManualShifted() && withSliding) {
-                // Shift has been pressed and slid out to other key.
-                mSwitchState = SWITCH_STATE_MOMENTARY_ALPHA_SHIFT;
             } else if (isShiftLocked && !mAlphabetShiftState.isShiftLockShifted()
                     && (mShiftKeyState.isPressing() || mShiftKeyState.isPressingOnShifted())
                     && !withSliding) {
@@ -580,9 +573,6 @@ public final class KeyboardState {
             break;
         case SWITCH_STATE_MOMENTARY_SYMBOL_AND_MORE:
             toggleShiftInSymbols();
-            break;
-        case SWITCH_STATE_MOMENTARY_ALPHA_SHIFT:
-            setAlphabetKeyboard(autoCapsFlags, recapitalizeMode);
             break;
         }
     }
@@ -654,7 +644,6 @@ public final class KeyboardState {
         case SWITCH_STATE_SYMBOL: return "SYMBOL";
         case SWITCH_STATE_MOMENTARY_ALPHA_AND_SYMBOL: return "MOMENTARY-ALPHA-SYMBOL";
         case SWITCH_STATE_MOMENTARY_SYMBOL_AND_MORE: return "MOMENTARY-SYMBOL-MORE";
-        case SWITCH_STATE_MOMENTARY_ALPHA_SHIFT: return "MOMENTARY-ALPHA_SHIFT";
         default: return null;
         }
     }


### PR DESCRIPTION
When sliding from shift to another key (not a more keys keyboard key) the keyboard is always changed to an unshifted state. In the case of a textCapCharacters field, selecting a character like `"` or `;` in a textCapWords field, or selecting a character like `"` after a `.` and a space in a textCapSentences field will result in an unshifted keyboard, even though auto-caps should have put it in a shifted state. If shift is pressed right after this, the first press does nothing. In a textCapCharacters field, the keyboard isn't re-shifted even after more characters are typed.

This fixes that problem. I'm not entirely sure what the `SWITCH_STATE_MOMENTARY_ALPHA_SHIFT` internal state was meant to solve, but it seems to only cause this bug, so I removed it.

I also removed a call to `setShiftLocked` when sliding off of the shift key when it was shift lock shifted. The keyboard is already shift locked, so call seems to have no value.