### PR TITLE
Disable auto-capitalization for certain keyboard layouts

### DIFF
--- a/app/src/main/java/rkr/simplekeyboard/inputmethod/latin/LatinIME.java
+++ b/app/src/main/java/rkr/simplekeyboard/inputmethod/latin/LatinIME.java
@@ -726,7 +726,8 @@ public class LatinIME extends InputMethodService implements KeyboardActionListen
     }
 
     int getCurrentAutoCapsState() {
-        return mInputLogic.getCurrentAutoCapsState(mSettings.getCurrent());
+        return mInputLogic.getCurrentAutoCapsState(mSettings.getCurrent(),
+                mRichImm.getCurrentSubtype().getKeyboardLayoutSetName());
     }
 
     int getCurrentRecapitalizeState() {

--- a/app/src/main/java/rkr/simplekeyboard/inputmethod/latin/inputlogic/InputLogic.java
+++ b/app/src/main/java/rkr/simplekeyboard/inputmethod/latin/inputlogic/InputLogic.java
@@ -422,10 +422,14 @@ public final class InputLogic {
      * needs to know auto caps state to display the right layout.
      *
      * @param settingsValues the relevant settings values
+     * @param layoutSetName the name of the current keyboard layout set
      * @return a caps mode from TextUtils.CAP_MODE_* or Constants.TextUtils.CAP_MODE_OFF.
      */
-    public int getCurrentAutoCapsState(final SettingsValues settingsValues) {
-        if (!settingsValues.mAutoCap) return Constants.TextUtils.CAP_MODE_OFF;
+    public int getCurrentAutoCapsState(final SettingsValues settingsValues,
+                                       final String layoutSetName) {
+        if (!settingsValues.mAutoCap || !layoutUsesAutoCaps(layoutSetName)) {
+            return Constants.TextUtils.CAP_MODE_OFF;
+        }
 
         final EditorInfo ei = getCurrentInputEditorInfo();
         if (ei == null) return Constants.TextUtils.CAP_MODE_OFF;
@@ -433,6 +437,33 @@ public final class InputLogic {
         // Warning: this depends on mSpaceState, which may not be the most current value. If
         // mSpaceState gets updated later, whoever called this may need to be told about it.
         return mConnection.getCursorCapsMode(inputType, settingsValues.mSpacingAndPunctuations);
+    }
+
+    private boolean layoutUsesAutoCaps(final String layoutSetName) {
+        switch (layoutSetName) {
+            case "arabic":
+            case "bengali":
+            case "bengali_akkhor":
+            case "farsi":
+            case "georgian":
+            case "hebrew":
+            case "hindi":
+            case "hindi_compact":
+            case "kannada":
+            case "khmer":
+            case "lao":
+            case "malayalam":
+            case "marathi":
+            case "nepali_romanized":
+            case "nepali_traditional":
+            case "tamil":
+            case "telugu":
+            case "thai":
+            case "urdu":
+                return false;
+            default:
+                return true;
+        }
     }
 
     public int getCurrentRecapitalizeState() {


### PR DESCRIPTION
Some keyboard layouts don't utilize auto-capitalization functionality, presumably because the languages don't have the concept of upper/lower case letters. For these layouts auto-capitalization still functions to change the shift key into an `alphabetAutomaticShifted` state. To actually do a manual shift in this case requires shift to be pressed to unshift (making no difference in the other keys that are shown) and then pressed again to actually shift and show alternate keys. To prevent this issue, I disabled auto-capitalization for certain keyboard layouts.

The following layouts have this issue:
- bengali_akkhor
- georgian
- hindi
- khmer
- lao
- nepali_romanized
- nepali_traditional
- thai
- urdu

The following layouts don't have the problem because they don't even have a shift key, but I still disabled auto-capitalization because it isn't necessary:
- arabic
- bengali
- hebrew
- hindi_compact
- kannada
- malayalam
- marathi
- farsi
- tamil
- telugu