### PR TITLE
Increase the keyboard height only when relevant

### DIFF
--- a/app/src/main/java/rkr/simplekeyboard/inputmethod/keyboard/internal/KeyboardBuilder.java
+++ b/app/src/main/java/rkr/simplekeyboard/inputmethod/keyboard/internal/KeyboardBuilder.java
@@ -247,8 +247,8 @@ public class KeyboardBuilder<KP extends KeyboardParams> {
             final int width = params.mId.mWidth;
             // The bonus height isn't used to determine the other dimensions (gap/padding) to allow
             // those to stay consistent between layouts with and without the bonus height added.
-            final int bonusHeight = mParams.mId.mShowNumberRow ? Math.round(mResources.getFraction(
-                    R.fraction.config_key_bonus_height_5row, height, height)) : 0;
+            final int bonusHeight = (int)keyboardAttr.getFraction(R.styleable.Keyboard_bonusHeight,
+                    height, height, 0);
             params.mOccupiedHeight = height + bonusHeight;
             params.mOccupiedWidth = width;
             params.mTopPadding = ResourceUtils.getDimensionOrFraction(keyboardAttr,

--- a/app/src/main/res/values/attrs.xml
+++ b/app/src/main/res/values/attrs.xml
@@ -129,6 +129,8 @@
         <attr name="horizontalGap" format="fraction" />
         <!-- Default vertical gap between rows of keys, in the proportion of keyboard height. -->
         <attr name="verticalGap" format="fraction" />
+        <!-- Extra height used for rows. This doesn't impact the size of paddings or gap. -->
+        <attr name="bonusHeight" format="fraction" />
         <!-- More keys keyboard layout template -->
         <attr name="moreKeysTemplate" format="reference" />
         <!-- Icon set for key top and key preview. These should be aligned with

--- a/app/src/main/res/xml/kbd_abc.xml
+++ b/app/src/main/res/xml/kbd_abc.xml
@@ -22,6 +22,7 @@
     <case latin:showNumberRow="true">
         <Keyboard
             latin:verticalGap="@fraction/config_key_vertical_gap_5row"
+            latin:bonusHeight="@fraction/config_key_bonus_height_5row"
             latin:rowHeight="20%p">
             <include latin:keyboardLayout="@xml/key_styles_common" />
             <include latin:keyboardLayout="@xml/row_qwerty0" />

--- a/app/src/main/res/xml/kbd_arabic.xml
+++ b/app/src/main/res/xml/kbd_arabic.xml
@@ -22,6 +22,7 @@
     <case latin:showNumberRow="true">
         <Keyboard
             latin:verticalGap="@fraction/config_key_vertical_gap_5row"
+            latin:bonusHeight="@fraction/config_key_bonus_height_5row"
             latin:rowHeight="20%p">
             <include latin:keyboardLayout="@xml/key_styles_common" />
             <include latin:keyboardLayout="@xml/row_qwerty0" />

--- a/app/src/main/res/xml/kbd_armenian_phonetic.xml
+++ b/app/src/main/res/xml/kbd_armenian_phonetic.xml
@@ -22,6 +22,7 @@
     xmlns:latin="http://schemas.android.com/apk/res-auto"
     latin:rowHeight="20%p"
     latin:verticalGap="@fraction/config_key_vertical_gap_5row"
+    latin:bonusHeight="@fraction/config_key_bonus_height_5row"
     latin:keyLetterSize="@fraction/config_key_letter_ratio_5row"
     latin:keyShiftedLetterHintRatio="@fraction/config_key_shifted_letter_hint_ratio_5row"
 >

--- a/app/src/main/res/xml/kbd_azerty.xml
+++ b/app/src/main/res/xml/kbd_azerty.xml
@@ -22,6 +22,7 @@
     <case latin:showNumberRow="true">
         <Keyboard
             latin:verticalGap="@fraction/config_key_vertical_gap_5row"
+            latin:bonusHeight="@fraction/config_key_bonus_height_5row"
             latin:rowHeight="20%p">
             <include latin:keyboardLayout="@xml/key_styles_common" />
             <include latin:keyboardLayout="@xml/row_qwerty0" />

--- a/app/src/main/res/xml/kbd_bulgarian.xml
+++ b/app/src/main/res/xml/kbd_bulgarian.xml
@@ -22,6 +22,7 @@
     <case latin:showNumberRow="true">
         <Keyboard
             latin:verticalGap="@fraction/config_key_vertical_gap_5row"
+            latin:bonusHeight="@fraction/config_key_bonus_height_5row"
             latin:rowHeight="20%p">
             <include latin:keyboardLayout="@xml/key_styles_common" />
             <include latin:keyboardLayout="@xml/row_qwerty0" />

--- a/app/src/main/res/xml/kbd_bulgarian_bds.xml
+++ b/app/src/main/res/xml/kbd_bulgarian_bds.xml
@@ -22,6 +22,7 @@
     <case latin:showNumberRow="true">
         <Keyboard
             latin:verticalGap="@fraction/config_key_vertical_gap_5row"
+            latin:bonusHeight="@fraction/config_key_bonus_height_5row"
             latin:rowHeight="20%p">
             <include latin:keyboardLayout="@xml/key_styles_common" />
             <include latin:keyboardLayout="@xml/row_qwerty0" />

--- a/app/src/main/res/xml/kbd_colemak.xml
+++ b/app/src/main/res/xml/kbd_colemak.xml
@@ -22,6 +22,7 @@
     <case latin:showNumberRow="true">
         <Keyboard
             latin:verticalGap="@fraction/config_key_vertical_gap_5row"
+            latin:bonusHeight="@fraction/config_key_bonus_height_5row"
             latin:rowHeight="20%p">
             <include latin:keyboardLayout="@xml/key_styles_common" />
             <include latin:keyboardLayout="@xml/row_qwerty0" />

--- a/app/src/main/res/xml/kbd_dvorak.xml
+++ b/app/src/main/res/xml/kbd_dvorak.xml
@@ -22,6 +22,7 @@
     <case latin:showNumberRow="true">
         <Keyboard
             latin:verticalGap="@fraction/config_key_vertical_gap_5row"
+            latin:bonusHeight="@fraction/config_key_bonus_height_5row"
             latin:rowHeight="20%p">
             <include latin:keyboardLayout="@xml/row_qwerty0" />
             <include latin:keyboardLayout="@xml/rows_dvorak" />

--- a/app/src/main/res/xml/kbd_east_slavic.xml
+++ b/app/src/main/res/xml/kbd_east_slavic.xml
@@ -22,6 +22,7 @@
     <case latin:showNumberRow="true">
         <Keyboard
             latin:verticalGap="@fraction/config_key_vertical_gap_5row"
+            latin:bonusHeight="@fraction/config_key_bonus_height_5row"
             latin:rowHeight="20%p">
             <include latin:keyboardLayout="@xml/key_styles_common" />
             <include latin:keyboardLayout="@xml/row_qwerty0" />

--- a/app/src/main/res/xml/kbd_georgian.xml
+++ b/app/src/main/res/xml/kbd_georgian.xml
@@ -22,6 +22,7 @@
     <case latin:showNumberRow="true">
         <Keyboard
             latin:verticalGap="@fraction/config_key_vertical_gap_5row"
+            latin:bonusHeight="@fraction/config_key_bonus_height_5row"
             latin:rowHeight="20%p">
             <include latin:keyboardLayout="@xml/key_styles_common" />
             <include latin:keyboardLayout="@xml/row_qwerty0" />

--- a/app/src/main/res/xml/kbd_greek.xml
+++ b/app/src/main/res/xml/kbd_greek.xml
@@ -22,6 +22,7 @@
     <case latin:showNumberRow="true">
         <Keyboard
             latin:verticalGap="@fraction/config_key_vertical_gap_5row"
+            latin:bonusHeight="@fraction/config_key_bonus_height_5row"
             latin:rowHeight="20%p">
             <include latin:keyboardLayout="@xml/key_styles_common" />
             <include latin:keyboardLayout="@xml/row_qwerty0" />

--- a/app/src/main/res/xml/kbd_hebrew.xml
+++ b/app/src/main/res/xml/kbd_hebrew.xml
@@ -22,6 +22,7 @@
     <case latin:showNumberRow="true">
         <Keyboard
             latin:verticalGap="@fraction/config_key_vertical_gap_5row"
+            latin:bonusHeight="@fraction/config_key_bonus_height_5row"
             latin:rowHeight="20%p">
             <include latin:keyboardLayout="@xml/key_styles_common" />
             <include latin:keyboardLayout="@xml/row_qwerty0" />

--- a/app/src/main/res/xml/kbd_hindi.xml
+++ b/app/src/main/res/xml/kbd_hindi.xml
@@ -22,6 +22,7 @@
     <case latin:showNumberRow="true">
         <Keyboard
             latin:verticalGap="@fraction/config_key_vertical_gap_5row"
+            latin:bonusHeight="@fraction/config_key_bonus_height_5row"
             latin:rowHeight="20%p">
             <include latin:keyboardLayout="@xml/key_styles_common" />
             <include latin:keyboardLayout="@xml/row_qwerty0" />

--- a/app/src/main/res/xml/kbd_hindi_compact.xml
+++ b/app/src/main/res/xml/kbd_hindi_compact.xml
@@ -22,6 +22,7 @@
     <case latin:showNumberRow="true">
         <Keyboard
             latin:verticalGap="@fraction/config_key_vertical_gap_5row"
+            latin:bonusHeight="@fraction/config_key_bonus_height_5row"
             latin:rowHeight="20%p">
             <include latin:keyboardLayout="@xml/key_styles_common" />
             <include latin:keyboardLayout="@xml/row_qwerty0" />

--- a/app/src/main/res/xml/kbd_kannada.xml
+++ b/app/src/main/res/xml/kbd_kannada.xml
@@ -22,6 +22,7 @@
     <case latin:showNumberRow="true">
         <Keyboard
             latin:verticalGap="@fraction/config_key_vertical_gap_5row"
+            latin:bonusHeight="@fraction/config_key_bonus_height_5row"
             latin:rowHeight="20%p">
             <include latin:keyboardLayout="@xml/key_styles_common" />
             <include latin:keyboardLayout="@xml/row_qwerty0" />

--- a/app/src/main/res/xml/kbd_khmer.xml
+++ b/app/src/main/res/xml/kbd_khmer.xml
@@ -22,6 +22,7 @@
     xmlns:latin="http://schemas.android.com/apk/res-auto"
     latin:rowHeight="20%p"
     latin:verticalGap="@fraction/config_key_vertical_gap_5row"
+    latin:bonusHeight="@fraction/config_key_bonus_height_5row"
     latin:keyLetterSize="@fraction/config_key_letter_ratio_5row"
     latin:keyShiftedLetterHintRatio="@fraction/config_key_shifted_letter_hint_ratio_5row"
 >

--- a/app/src/main/res/xml/kbd_lao.xml
+++ b/app/src/main/res/xml/kbd_lao.xml
@@ -22,6 +22,7 @@
     xmlns:latin="http://schemas.android.com/apk/res-auto"
     latin:rowHeight="20%p"
     latin:verticalGap="@fraction/config_key_vertical_gap_5row"
+    latin:bonusHeight="@fraction/config_key_bonus_height_5row"
     latin:keyLetterSize="@fraction/config_key_letter_ratio_5row"
     latin:keyShiftedLetterHintRatio="@fraction/config_key_shifted_letter_hint_ratio_5row"
 >

--- a/app/src/main/res/xml/kbd_malayalam.xml
+++ b/app/src/main/res/xml/kbd_malayalam.xml
@@ -22,6 +22,7 @@
     <case latin:showNumberRow="true">
         <Keyboard
             latin:verticalGap="@fraction/config_key_vertical_gap_5row"
+            latin:bonusHeight="@fraction/config_key_bonus_height_5row"
             latin:rowHeight="20%p">
             <include latin:keyboardLayout="@xml/key_styles_common" />
             <include latin:keyboardLayout="@xml/row_qwerty0" />

--- a/app/src/main/res/xml/kbd_marathi.xml
+++ b/app/src/main/res/xml/kbd_marathi.xml
@@ -22,6 +22,7 @@
     <case latin:showNumberRow="true">
         <Keyboard
             latin:verticalGap="@fraction/config_key_vertical_gap_5row"
+            latin:bonusHeight="@fraction/config_key_bonus_height_5row"
             latin:rowHeight="20%p">
             <include latin:keyboardLayout="@xml/key_styles_common" />
             <include latin:keyboardLayout="@xml/row_qwerty0" />

--- a/app/src/main/res/xml/kbd_mongolian.xml
+++ b/app/src/main/res/xml/kbd_mongolian.xml
@@ -22,6 +22,7 @@
     <case latin:showNumberRow="true">
         <Keyboard
             latin:verticalGap="@fraction/config_key_vertical_gap_5row"
+            latin:bonusHeight="@fraction/config_key_bonus_height_5row"
             latin:rowHeight="20%p">
             <include latin:keyboardLayout="@xml/key_styles_common" />
             <include latin:keyboardLayout="@xml/row_qwerty0" />

--- a/app/src/main/res/xml/kbd_nepali_romanized.xml
+++ b/app/src/main/res/xml/kbd_nepali_romanized.xml
@@ -22,6 +22,7 @@
     <case latin:showNumberRow="true">
         <Keyboard
             latin:verticalGap="@fraction/config_key_vertical_gap_5row"
+            latin:bonusHeight="@fraction/config_key_bonus_height_5row"
             latin:rowHeight="20%p">
             <include latin:keyboardLayout="@xml/key_styles_common" />
             <include latin:keyboardLayout="@xml/row_qwerty0" />

--- a/app/src/main/res/xml/kbd_nepali_traditional.xml
+++ b/app/src/main/res/xml/kbd_nepali_traditional.xml
@@ -22,6 +22,7 @@
     <case latin:showNumberRow="true">
         <Keyboard
             latin:verticalGap="@fraction/config_key_vertical_gap_5row"
+            latin:bonusHeight="@fraction/config_key_bonus_height_5row"
             latin:rowHeight="20%p">
             <include latin:keyboardLayout="@xml/key_styles_common" />
             <include latin:keyboardLayout="@xml/row_qwerty0" />

--- a/app/src/main/res/xml/kbd_nordic.xml
+++ b/app/src/main/res/xml/kbd_nordic.xml
@@ -22,6 +22,7 @@
     <case latin:showNumberRow="true">
         <Keyboard
             latin:verticalGap="@fraction/config_key_vertical_gap_5row"
+            latin:bonusHeight="@fraction/config_key_bonus_height_5row"
             latin:rowHeight="20%p">
             <include latin:keyboardLayout="@xml/key_styles_common" />
             <include latin:keyboardLayout="@xml/row_qwerty0" />

--- a/app/src/main/res/xml/kbd_pcqwerty.xml
+++ b/app/src/main/res/xml/kbd_pcqwerty.xml
@@ -22,6 +22,7 @@
     xmlns:latin="http://schemas.android.com/apk/res-auto"
     latin:rowHeight="20%p"
     latin:verticalGap="@fraction/config_key_vertical_gap_5row"
+    latin:bonusHeight="@fraction/config_key_bonus_height_5row"
     latin:keyLetterSize="@fraction/config_key_letter_ratio_5row"
     latin:keyShiftedLetterHintRatio="@fraction/config_key_shifted_letter_hint_ratio_5row"
 >

--- a/app/src/main/res/xml/kbd_qwerty.xml
+++ b/app/src/main/res/xml/kbd_qwerty.xml
@@ -22,6 +22,7 @@
     <case latin:showNumberRow="true">
         <Keyboard
             latin:verticalGap="@fraction/config_key_vertical_gap_5row"
+            latin:bonusHeight="@fraction/config_key_bonus_height_5row"
             latin:rowHeight="20%p">
             <include latin:keyboardLayout="@xml/key_styles_common" />
             <include latin:keyboardLayout="@xml/row_qwerty0" />

--- a/app/src/main/res/xml/kbd_qwertz.xml
+++ b/app/src/main/res/xml/kbd_qwertz.xml
@@ -22,6 +22,7 @@
     <case latin:showNumberRow="true">
         <Keyboard
             latin:verticalGap="@fraction/config_key_vertical_gap_5row"
+            latin:bonusHeight="@fraction/config_key_bonus_height_5row"
             latin:rowHeight="20%p">
             <include latin:keyboardLayout="@xml/key_styles_common" />
             <include latin:keyboardLayout="@xml/row_qwerty0" />

--- a/app/src/main/res/xml/kbd_serbian_qwertz.xml
+++ b/app/src/main/res/xml/kbd_serbian_qwertz.xml
@@ -22,6 +22,7 @@
     <case latin:showNumberRow="true">
         <Keyboard
             latin:verticalGap="@fraction/config_key_vertical_gap_5row"
+            latin:bonusHeight="@fraction/config_key_bonus_height_5row"
             latin:rowHeight="20%p">
             <include latin:keyboardLayout="@xml/key_styles_common" />
             <include latin:keyboardLayout="@xml/row_qwerty0" />

--- a/app/src/main/res/xml/kbd_south_slavic.xml
+++ b/app/src/main/res/xml/kbd_south_slavic.xml
@@ -22,6 +22,7 @@
     <case latin:showNumberRow="true">
         <Keyboard
             latin:verticalGap="@fraction/config_key_vertical_gap_5row"
+            latin:bonusHeight="@fraction/config_key_bonus_height_5row"
             latin:rowHeight="20%p">
             <include latin:keyboardLayout="@xml/key_styles_common" />
             <include latin:keyboardLayout="@xml/row_qwerty0" />

--- a/app/src/main/res/xml/kbd_spanish.xml
+++ b/app/src/main/res/xml/kbd_spanish.xml
@@ -22,6 +22,7 @@
     <case latin:showNumberRow="true">
         <Keyboard
             latin:verticalGap="@fraction/config_key_vertical_gap_5row"
+            latin:bonusHeight="@fraction/config_key_bonus_height_5row"
             latin:rowHeight="20%p">
             <include latin:keyboardLayout="@xml/key_styles_common" />
             <include latin:keyboardLayout="@xml/row_qwerty0" />

--- a/app/src/main/res/xml/kbd_swiss.xml
+++ b/app/src/main/res/xml/kbd_swiss.xml
@@ -22,6 +22,7 @@
     <case latin:showNumberRow="true">
         <Keyboard
             latin:verticalGap="@fraction/config_key_vertical_gap_5row"
+            latin:bonusHeight="@fraction/config_key_bonus_height_5row"
             latin:rowHeight="20%p">
             <include latin:keyboardLayout="@xml/key_styles_common" />
             <include latin:keyboardLayout="@xml/row_qwerty0" />

--- a/app/src/main/res/xml/kbd_symbols.xml
+++ b/app/src/main/res/xml/kbd_symbols.xml
@@ -18,9 +18,34 @@
 */
 -->
 
-<Keyboard
-    xmlns:latin="http://schemas.android.com/apk/res-auto"
->
-    <include
-        latin:keyboardLayout="@xml/rows_symbols" />
-</Keyboard>
+<switch xmlns:latin="http://schemas.android.com/apk/res-auto">
+    <case latin:languageCode="bn|fa|ur">
+        <!-- The bengali, bengali_akkhor, farsi, and urdu keyboards currently don't support a
+             separate number row. -->
+        <Keyboard>
+            <include
+                latin:keyboardLayout="@xml/rows_symbols" />
+        </Keyboard>
+    </case>
+    <case latin:showNumberRow="true">
+        <Keyboard
+            latin:bonusHeight="@fraction/config_key_bonus_height_5row">
+            <include
+                latin:keyboardLayout="@xml/rows_symbols" />
+        </Keyboard>
+    </case>
+    <case latin:languageCode="hy|km|lo|th">
+        <!-- The armenian_phonetic, khmer, lao, and thai keyboards always have 5 rows. -->
+        <Keyboard
+            latin:bonusHeight="@fraction/config_key_bonus_height_5row">
+            <include
+                latin:keyboardLayout="@xml/rows_symbols" />
+        </Keyboard>
+    </case>
+    <default>
+        <Keyboard>
+            <include
+                latin:keyboardLayout="@xml/rows_symbols" />
+        </Keyboard>
+    </default>
+</switch>

--- a/app/src/main/res/xml/kbd_symbols_shift.xml
+++ b/app/src/main/res/xml/kbd_symbols_shift.xml
@@ -18,9 +18,34 @@
 */
 -->
 
-<Keyboard
-    xmlns:latin="http://schemas.android.com/apk/res-auto"
->
-    <include
-        latin:keyboardLayout="@xml/rows_symbols_shift" />
-</Keyboard>
+<switch xmlns:latin="http://schemas.android.com/apk/res-auto">
+    <case latin:languageCode="bn|fa|ur">
+        <!-- The bengali, bengali_akkhor, farsi, and urdu keyboards currently don't support a
+             separate number row. -->
+        <Keyboard>
+            <include
+                latin:keyboardLayout="@xml/rows_symbols_shift" />
+        </Keyboard>
+    </case>
+    <case latin:showNumberRow="true">
+        <Keyboard
+            latin:bonusHeight="@fraction/config_key_bonus_height_5row">
+            <include
+                latin:keyboardLayout="@xml/rows_symbols_shift" />
+        </Keyboard>
+    </case>
+    <case latin:languageCode="hy|km|lo|th">
+        <!-- The armenian_phonetic, khmer, lao, and thai keyboards always have 5 rows. -->
+        <Keyboard
+            latin:bonusHeight="@fraction/config_key_bonus_height_5row">
+            <include
+                latin:keyboardLayout="@xml/rows_symbols_shift" />
+        </Keyboard>
+    </case>
+    <default>
+        <Keyboard>
+            <include
+                latin:keyboardLayout="@xml/rows_symbols_shift" />
+        </Keyboard>
+    </default>
+</switch>

--- a/app/src/main/res/xml/kbd_tamil.xml
+++ b/app/src/main/res/xml/kbd_tamil.xml
@@ -22,6 +22,7 @@
     <case latin:showNumberRow="true">
         <Keyboard
             latin:verticalGap="@fraction/config_key_vertical_gap_5row"
+            latin:bonusHeight="@fraction/config_key_bonus_height_5row"
             latin:rowHeight="20%p">
             <include latin:keyboardLayout="@xml/key_styles_common" />
             <include latin:keyboardLayout="@xml/row_qwerty0" />

--- a/app/src/main/res/xml/kbd_telugu.xml
+++ b/app/src/main/res/xml/kbd_telugu.xml
@@ -22,6 +22,7 @@
     <case latin:showNumberRow="true">
         <Keyboard
             latin:verticalGap="@fraction/config_key_vertical_gap_5row"
+            latin:bonusHeight="@fraction/config_key_bonus_height_5row"
             latin:rowHeight="20%p">
             <include latin:keyboardLayout="@xml/key_styles_common" />
             <include latin:keyboardLayout="@xml/row_qwerty0" />

--- a/app/src/main/res/xml/kbd_thai.xml
+++ b/app/src/main/res/xml/kbd_thai.xml
@@ -22,6 +22,7 @@
     xmlns:latin="http://schemas.android.com/apk/res-auto"
     latin:rowHeight="20%p"
     latin:verticalGap="@fraction/config_key_vertical_gap_5row"
+    latin:bonusHeight="@fraction/config_key_bonus_height_5row"
     latin:keyLetterSize="@fraction/config_key_letter_ratio_5row"
     latin:keyShiftedLetterHintRatio="@fraction/config_key_shifted_letter_hint_ratio_5row"
 >

--- a/app/src/main/res/xml/kbd_uzbek.xml
+++ b/app/src/main/res/xml/kbd_uzbek.xml
@@ -22,6 +22,7 @@
     <case latin:showNumberRow="true">
         <Keyboard
             latin:verticalGap="@fraction/config_key_vertical_gap_5row"
+            latin:bonusHeight="@fraction/config_key_bonus_height_5row"
             latin:rowHeight="20%p">
             <include latin:keyboardLayout="@xml/key_styles_common" />
             <include latin:keyboardLayout="@xml/row_qwerty0" />


### PR DESCRIPTION
When adding the number row, we increase the height of the keyboard to allow extra keys. The armenian_phonetic, khmer, lao, pcqwerty, and thai keyboards always have 5 rows, so they could benefit from the extra height normally given for the number row. Now these layouts always get the extra height, regardless of the number row setting. 

Also, the bengali, bengali_akkhor, farsi, and urdu keyboards currently don't support a separate number row, so it doesn't add any value to increase the height of these keyboards when the number row setting is enabled. It just wastes screen space. Now these layouts don't increase the keyboard height, even when the number row setting is on.

Similarly, the non-alphabet keyboards (number, phone, phone_symbols) don't benefit from the extra height, so these won't change height, even when the number row setting is enabled. Since different text fields need to be selected to see a difference in the height of the keyboard, I don't think this will be problematic to users. Since the symbols and symbols_shift keyboards are tied to the alphabet keyboards, it probably would look bad/confusing to change heights when switching between them, so those still match the height of the alphabet keyboards. Gboard also doesn't increase the height of the other non-alphabet keyboards.

You said in #132 that you thought dynamic heights would require a significant refactor to rendering code. I'm not sure if you misunderstood what I was going to do or if I'm overlooking something, but I didn't need to mess with rendering code, and it seems to work fine. You also mentioned concern over how input apps would react, but I haven't noticed any issues. It might scroll a bit, but since the change is from selecting a new text field, it doesn't seem like that's actually a problem.