### PR TITLE
Interoperability and currency improvements for East Slavic languages

### DIFF
--- a/app/src/main/java/rkr/simplekeyboard/inputmethod/keyboard/internal/KeyboardTextsTable.java
+++ b/app/src/main/java/rkr/simplekeyboard/inputmethod/keyboard/internal/KeyboardTextsTable.java
@@ -3084,8 +3084,9 @@ public final class KeyboardTextsTable {
         /* double_quotes */ "!text/double_9qm_lqm",
         /* morekeys_s */ null,
         /* single_quotes */ "!text/single_9qm_lqm",
-        /* keyspec_currency ~ */
-        null, null, null, null, null, null, null, null, null, null, null,
+        // U+20BD ₽ RUBLE SIGN
+        /* keyspec_currency */ "\u20BD",
+        null, null, null, null, null, null, null, null, null, null,
         /* ~ morekeys_k */
         // U+0451: "ё" CYRILLIC SMALL LETTER IO
         // U+0463: "ѣ" CYRILLIC SMALL LETTER YAT

--- a/app/src/main/java/rkr/simplekeyboard/inputmethod/keyboard/internal/KeyboardTextsTable.java
+++ b/app/src/main/java/rkr/simplekeyboard/inputmethod/keyboard/internal/KeyboardTextsTable.java
@@ -3088,7 +3088,8 @@ public final class KeyboardTextsTable {
         null, null, null, null, null, null, null, null, null, null, null,
         /* ~ morekeys_k */
         // U+0451: "ё" CYRILLIC SMALL LETTER IO
-        /* morekeys_cyrillic_ie */ "\u0451",
+        // U+0463: "ѣ" CYRILLIC SMALL LETTER YAT
+        /* morekeys_cyrillic_ie */ "\u0451,\u0463",
         /* keyspec_nordic_row1_11 ~ */
         null, null, null, null,
         /* ~ morekeys_nordic_row2_10 */
@@ -3102,6 +3103,29 @@ public final class KeyboardTextsTable {
         /* keyspec_east_slavic_row3_5 */ "\u0438",
         // U+044A: "ъ" CYRILLIC SMALL LETTER HARD SIGN
         /* morekeys_cyrillic_soft_sign */ "\u044A",
+        null, null, null, null, null, null, null, null, null, null,/* 32-*/
+        null, null, null, null, null, null, null, null, null, null,/* 42-*/
+        null, null, null, null, null, null, null, null, null, null,/* 52-*/
+        null, null, null, null, null, null, null, null, null, null,/* 62-*/
+        null, null, null, null, null, null, null, null, null, null,/* 72-*/
+        null, null, null, null, null,
+        // U+A651: "ꙑ" CYRILLIC SMALL LETTER YERU WITH BACK YER
+        /* morekeys_east_slavic_row2_2 */ "\uA651",
+        // U+045E: "ў" CYRILLIC SMALL LETTER SHORT U
+        /* morekeys_cyrillic_u */ "\u045E",
+        /* morekeys_cyrillic_en */ null,
+        // U+0491: "ґ" CYRILLIC SMALL LETTER GHE WITH UPTURN
+        /* morekeys_cyrillic_ghe */ "\u0491",
+        /* morekeys_cyrillic_o */ null,
+        // U+0456: "і" CYRILLIC SMALL LETTER BYELORUSSIAN-UKRAINIAN I
+        // U+0457: "ї" CYRILLIC SMALL LETTER YI
+        // U+0475: "ѵ" CYRILLIC SMALL LETTER IZHITSA
+        /* morekeys_cyrillic_i */ "\u0456,\u0457,\u0475",
+        null, null, null, null, null, null, null, null, null,/* 92-*/
+        null, null, null, null, null, null, null, null, null, null,/* 102-*/
+        null, null, null, null, null, null, null, null, /* 112-119 */
+        // U+0454: "є" CYRILLIC SMALL LETTER UKRAINIAN IE
+        /* morekeys_east_slavic_row2_11 */ "\u0454",
     };
 
     /* Locale si_LK: Sinhalese (Sri Lanka) */
@@ -3711,6 +3735,15 @@ public final class KeyboardTextsTable {
         /* morekeys_cyrillic_en */ null,
         // U+0491: "ґ" CYRILLIC SMALL LETTER GHE WITH UPTURN
         /* morekeys_cyrillic_ghe */ "\u0491",
+        /* morekeys_cyrillic_o */ null,
+        // U+044B: "ы" CYRILLIC SMALL LETTER YERU
+        // U+A651: "ꙑ" CYRILLIC SMALL LETTER YERU WITH BACK YER
+        /* morekeys_cyrillic_i */ "\u044B,\uA651",
+        null, null, null, null, null, null, null, null,
+        null, null, null, null, null, null, null, null, null, null,
+        null, null, null, null, null, null, null, null, null,
+        // U+044D: "э" CYRILLIC SMALL LETTER E
+        /* morekeys_east_slavic_row2_11 */ "\u044D",
     };
 
     /* Locale ur: Urdu */

--- a/app/src/main/java/rkr/simplekeyboard/inputmethod/latin/settings/InputMethodSettingsFragment.java
+++ b/app/src/main/java/rkr/simplekeyboard/inputmethod/latin/settings/InputMethodSettingsFragment.java
@@ -18,6 +18,7 @@ package rkr.simplekeyboard.inputmethod.latin.settings;
 import android.content.Context;
 import android.graphics.drawable.Drawable;
 import android.os.Bundle;
+import android.os.Handler;
 import android.preference.PreferenceFragment;
 
 import rkr.simplekeyboard.inputmethod.compat.PreferenceManagerCompat;
@@ -29,6 +30,14 @@ import rkr.simplekeyboard.inputmethod.compat.PreferenceManagerCompat;
 public abstract class InputMethodSettingsFragment extends PreferenceFragment
         implements InputMethodSettingsInterface {
     private final InputMethodSettingsImpl mSettings = new InputMethodSettingsImpl();
+    private final Handler handler =new Handler();
+    private final Runnable refreshSubtypeRunnable = new Runnable() {
+        @Override
+        public void run() {
+            mSettings.updateSubtypeEnabler();
+        }
+    };
+
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -84,6 +93,12 @@ public abstract class InputMethodSettingsFragment extends PreferenceFragment
     @Override
     public void onResume() {
         super.onResume();
-        mSettings.updateSubtypeEnabler();
+        handler.postDelayed(refreshSubtypeRunnable, 1000);
+    }
+
+    @Override
+    public void onPause() {
+        super.onPause();
+        handler.removeCallbacksAndMessages(null);
     }
 }

--- a/app/src/main/res/xml/rowkeys_east_slavic2.xml
+++ b/app/src/main/res/xml/rowkeys_east_slavic2.xml
@@ -34,8 +34,8 @@
             <!-- U+0432: "в" CYRILLIC SMALL LETTER VE -->
             <Key
                 latin:keySpec="&#x0432;"
-                latin:keyHintLabel="$"
-                latin:additionalMoreKeys="$" />
+                latin:keyHintLabel="!text/keyspec_currency"
+                latin:additionalMoreKeys="!text/keyspec_currency" />
             <!-- U+0430: "а" CYRILLIC SMALL LETTER A -->
             <Key
                 latin:keySpec="&#x0430;"

--- a/app/src/main/res/xml/rowkeys_east_slavic3.xml
+++ b/app/src/main/res/xml/rowkeys_east_slavic3.xml
@@ -35,7 +35,7 @@
             <Key
                 latin:keySpec="&#x0441;"
                 latin:keyHintLabel="&apos;"
-                latin:additionalMoreKeys="&apos;" />
+                latin:additionalMoreKeys="&apos;,&#x301;,&#x300;" />
             <!-- U+043C: "м" CYRILLIC SMALL LETTER EM -->
             <Key
                 latin:keySpec="&#x043C;"

--- a/app/src/main/res/xml/rowkeys_east_slavic3.xml
+++ b/app/src/main/res/xml/rowkeys_east_slavic3.xml
@@ -41,8 +41,11 @@
                 latin:keySpec="&#x043C;"
                 latin:keyHintLabel=":"
                 latin:additionalMoreKeys=":" />
+            <!-- This button's keyspec is "и" or "і" -->
+            <!-- morekeys has all other letters, excluding keyspec -->
             <Key
                 latin:keySpec="!text/keyspec_east_slavic_row3_5"
+                latin:moreKeys="!text/morekeys_cyrillic_i"
                 latin:keyHintLabel=";"
                 latin:additionalMoreKeys=";" />
             <!-- U+0442: "т" CYRILLIC SMALL LETTER TE -->
@@ -80,8 +83,11 @@
             <!-- U+043C: "м" CYRILLIC SMALL LETTER EM -->
             <Key
                 latin:keySpec="&#x043C;" />
+            <!-- This button's keyspec is "и" or "і" -->
+            <!-- morekeys has all other letters, excluding keyspec -->
             <Key
-                latin:keySpec="!text/keyspec_east_slavic_row3_5" />
+                latin:keySpec="!text/keyspec_east_slavic_row3_5"
+                latin:moreKeys="!text/morekeys_cyrillic_i" />
             <!-- U+0442: "т" CYRILLIC SMALL LETTER TE -->
             <Key
                 latin:keySpec="&#x0442;" />


### PR DESCRIPTION
These changes make it much easier to type some Ukrainian letters on Russian layout without constant switching to Ukrainian layout.

I noticed that I wasn't supposed to edit `KeyboardTextsTable` class, but I haven't found these tools to generate it.
I made this PR anyway. Can you, please, guide me how to do it the right way, @rkkr?