### PR TITLE
Fix Esperanto layout

### DIFF
--- a/app/src/main/java/rkr/simplekeyboard/inputmethod/keyboard/internal/KeyboardTextsTable.java
+++ b/app/src/main/java/rkr/simplekeyboard/inputmethod/keyboard/internal/KeyboardTextsTable.java
@@ -1253,7 +1253,7 @@ public final class KeyboardTextsTable {
         // U+0175: "ŵ" LATIN SMALL LETTER W WITH CIRCUMFLEX
         /* morekeys_w */ "w,\u0175",
         /* morekeys_east_slavic_row2_2 ~ */
-        null, null, null, null, null, null, null, null, null, null,
+        null, null, null, null, null, null, null, null, null, null, null,
         /* ~ morekeys_tablet_punctuation */
         // U+0135: "ĵ" LATIN SMALL LETTER J WITH CIRCUMFLEX
         /* keyspec_spanish_row2_10 */ "\u0135",


### PR DESCRIPTION
It seems like Esperanto layout was modified by accident in commit b37c5edce7767d4a2d18c1afcc5ef0335bb81bae :

![simple-keyboard-Eo-layout-bug](https://user-images.githubusercontent.com/36656205/114297489-82582300-9ae3-11eb-845c-caa0958ff691.png)

The original layout:

![image](https://user-images.githubusercontent.com/36656205/114297672-918ba080-9ae4-11eb-9298-464a715a03b1.png)
