### PR TITLE
Fix displaying the language on the spacebar

### DIFF
--- a/app/src/main/java/rkr/simplekeyboard/inputmethod/latin/utils/LanguageOnSpacebarUtils.java
+++ b/app/src/main/java/rkr/simplekeyboard/inputmethod/latin/utils/LanguageOnSpacebarUtils.java
@@ -18,10 +18,10 @@ package rkr.simplekeyboard.inputmethod.latin.utils;
 
 import android.view.inputmethod.InputMethodSubtype;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 
+import rkr.simplekeyboard.inputmethod.latin.RichInputMethodManager;
 import rkr.simplekeyboard.inputmethod.latin.RichInputMethodSubtype;
 
 /**
@@ -32,19 +32,12 @@ public final class LanguageOnSpacebarUtils {
     public static final int FORMAT_TYPE_LANGUAGE_ONLY = 1;
     public static final int FORMAT_TYPE_FULL_LOCALE = 2;
 
-    private static List<InputMethodSubtype> sEnabledSubtypes = Collections.emptyList();
-    private static boolean sIsSystemLanguageSameAsInputLanguage;
-
     private LanguageOnSpacebarUtils() {
         // This utility class is not publicly instantiable.
     }
 
     public static int getLanguageOnSpacebarFormatType(
             final RichInputMethodSubtype subtype) {
-        // Only this subtype is enabled and equals to the system locale.
-        if (sEnabledSubtypes.size() < 2 && sIsSystemLanguageSameAsInputLanguage) {
-            return FORMAT_TYPE_NONE;
-        }
         final Locale locale = subtype.getLocale();
         if (locale == null) {
             return FORMAT_TYPE_NONE;
@@ -52,7 +45,9 @@ public final class LanguageOnSpacebarUtils {
         final String keyboardLanguage = locale.getLanguage();
         final String keyboardLayout = subtype.getKeyboardLayoutSetName();
         int sameLanguageAndLayoutCount = 0;
-        for (final InputMethodSubtype ims : sEnabledSubtypes) {
+        final List<InputMethodSubtype> enabledSubtypes =
+                RichInputMethodManager.getInstance().getMyEnabledInputMethodSubtypeList(true);
+        for (final InputMethodSubtype ims : enabledSubtypes) {
             final String language = SubtypeLocaleUtils.getSubtypeLocale(ims).getLanguage();
             if (keyboardLanguage.equals(language) && keyboardLayout.equals(
                     SubtypeLocaleUtils.getKeyboardLayoutSetName(ims))) {
@@ -63,25 +58,5 @@ public final class LanguageOnSpacebarUtils {
         // locale and keyboard layout. Otherwise displaying language name is enough.
         return sameLanguageAndLayoutCount > 1 ? FORMAT_TYPE_FULL_LOCALE
                 : FORMAT_TYPE_LANGUAGE_ONLY;
-    }
-
-    public static void setEnabledSubtypes(final List<InputMethodSubtype> enabledSubtypes) {
-        sEnabledSubtypes = enabledSubtypes;
-    }
-
-    public static void onSubtypeChanged(final RichInputMethodSubtype subtype,
-           final boolean implicitlyEnabledSubtype, final Locale systemLocale) {
-        final Locale newLocale = subtype.getLocale();
-        if (systemLocale.equals(newLocale)) {
-            sIsSystemLanguageSameAsInputLanguage = true;
-            return;
-        }
-        if (!systemLocale.getLanguage().equals(newLocale.getLanguage())) {
-            sIsSystemLanguageSameAsInputLanguage = false;
-            return;
-        }
-        // If the subtype is enabled explicitly, the language name should be displayed even when
-        // the keyboard language and the system language are equal.
-        sIsSystemLanguageSameAsInputLanguage = implicitlyEnabledSubtype;
     }
 }


### PR DESCRIPTION
This fixes the displaying language on spacebar when multiple locales are enabled that use the same language and layout. For example, when English (US) QWERTY and English (UK) QWERTY are enabled and the US subtype is selected, "English (US)" should be shown on the spacebar, but if the UK subtype is disabled (and there is at least one other subtype enabled), it should just show "English".

I realized that in my changes in #274, I overlooked that `RichInputMethodManager::updateShortcutIme` called into `LanguageOnSpacebarUtils::onSubtypeChanged` and `LanguageOnSpacebarUtils::setEnabledSubtypes`, which left `sEnabledSubtypes` and `sIsSystemLanguageSameAsInputLanguage` always being the default value and broke this case.

`MainKeyboardView::onDrawKeyTopVisuals` only draws the language on the spacebar when there are multiple explicitly enabled subtypes, so the check in `getLanguageOnSpacebarFormatType` using `sIsSystemLanguageSameAsInputLanguage` always was false, so I just got rid of it.

`RichInputMethodManager` already caches subtype lists, so it doesn't seem necessary to also cache it in `LanguageOnSpacebarUtils` too.

Now `RichInputMethodManager` doesn't need to set values in `LanguageOnSpacebarUtils`.