### PR TITLE
Add CustomInputStyleSettingFragment back as a valid fragment

### DIFF
--- a/app/src/main/java/rkr/simplekeyboard/inputmethod/latin/utils/FragmentUtils.java
+++ b/app/src/main/java/rkr/simplekeyboard/inputmethod/latin/utils/FragmentUtils.java
@@ -19,6 +19,7 @@ package rkr.simplekeyboard.inputmethod.latin.utils;
 import java.util.HashSet;
 
 import rkr.simplekeyboard.inputmethod.latin.settings.AppearanceSettingsFragment;
+import rkr.simplekeyboard.inputmethod.latin.settings.CustomInputStyleSettingsFragment;
 import rkr.simplekeyboard.inputmethod.latin.settings.KeyPressSettingsFragment;
 import rkr.simplekeyboard.inputmethod.latin.settings.PreferencesSettingsFragment;
 import rkr.simplekeyboard.inputmethod.latin.settings.SettingsFragment;
@@ -31,6 +32,7 @@ public class FragmentUtils {
         sLatinImeFragments.add(KeyPressSettingsFragment.class.getName());
         sLatinImeFragments.add(AppearanceSettingsFragment.class.getName());
         sLatinImeFragments.add(ThemeSettingsFragment.class.getName());
+        sLatinImeFragments.add(CustomInputStyleSettingsFragment.class.getName());
         sLatinImeFragments.add(SettingsFragment.class.getName());
     }
 


### PR DESCRIPTION
Fix the crash in #280. In #270 I initially removed `CustomInputStyleSettingFragment` but ended up reverting that part and adding it back, but I missed adding `CustomInputStyleSettingFragment` back in `FragmentUtils` as a valid fragment.

For some reason `PreferenceActivity::isValidFragment` only seems to get called for `SettingsFragment` on newer versions of Android, rather than on every fragment that is opened, so I think this bug only affects some older versions (I didn't figure out exactly when it changed).