### PR TITLE
Fix the dialog theme on Android 9

### DIFF
--- a/app/src/main/res/values-night-v29/platform-theme.xml
+++ b/app/src/main/res/values-night-v29/platform-theme.xml
@@ -19,6 +19,5 @@
 -->
 
 <resources>
-    <style name="platformSettingsTheme" parent="@android:style/Theme.DeviceDefault.Settings" />
-    <style name="platformViewTheme" parent="@android:style/Theme.Material" />
+    <style name="platformDialogTheme" parent="@android:style/Theme.DeviceDefault.Dialog" />
 </resources>


### PR DESCRIPTION
This fixes an issue with the Input options dialog (long press the `,` key). In Android 9 if night mode is enabled, the dialog is themed dark. This doesn't match the system's input method picker dialog, which stays light even when night mode is on. I think it would make sense for these to match.

As some background info, the night mode implementation of Android 9 seems somewhat inconsistent along with not really being complete. There are 2 settings for a dark theme that I know of: `Display > Advanced > Device theme` and `System > Advanced > Developer options > Night mode`. On my phone, setting the Device theme changed things like the color of the Quick Settings menu (regardless of the Night mode setting). My phone was actually set to automatic Night mode, but the only things that I've noticed that change on my phone base on the time of day is the keyboard when using system default theme and this dialog. On an emulator, setting the Device theme seemed to have no effect, but setting Night mode changed things like the Quick Settings menu. I'm not completely sure why these are different, but in all of these cases I tested, the system's input method picker dialog was always light.

This change makes the dialog always light themed in Android 9 to more closely match how the rest of the system handles the night mode setting. Everything else should be the same. In more recent versions of Android, the dialog should still match the light/dark theme since the rest of the system actually changes too. Also, the system default keyboard theme should still match the night mode, even on Android 9.