### PR TITLE
Add a subtype for the keyboard

### DIFF
--- a/app/src/main/res/xml/method.xml
+++ b/app/src/main/res/xml/method.xml
@@ -23,4 +23,7 @@
 <input-method xmlns:android="http://schemas.android.com/apk/res/android"
         android:settingsActivity="rkr.simplekeyboard.inputmethod.latin.settings.SettingsActivity"
         android:supportsSwitchingToNextInputMethod="true">
+    <subtype android:icon="@drawable/ic_ime_switcher_dark"
+        android:imeSubtypeMode="keyboard"
+        android:isAsciiCapable="true" />
 </input-method>


### PR DESCRIPTION
This fixes the issue where Gboard can't be disabled when Simple Keyboard is the only other keyboard that is enabled. Apparently a subtype needs to be explicitly defined for the keyboard.