### PR TITLE
Improve new language flow

### DIFF
--- a/app/src/main/java/rkr/simplekeyboard/inputmethod/latin/settings/LanguagesSettingsFragment.java
+++ b/app/src/main/java/rkr/simplekeyboard/inputmethod/latin/settings/LanguagesSettingsFragment.java
@@ -17,9 +17,6 @@
 package rkr.simplekeyboard.inputmethod.latin.settings;
 
 import android.app.AlertDialog;
-import android.app.Fragment;
-import android.app.FragmentManager;
-import android.app.FragmentTransaction;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.os.Bundle;
@@ -113,6 +110,13 @@ public final class LanguagesSettingsFragment extends PreferenceFragment {
             showRemoveLanguagePopup();
         }
         return super.onOptionsItemSelected(item);
+    }
+
+    @Override
+    public void onPrepareOptionsMenu (Menu menu) {
+        if (mUsedLocaleNames != null) {
+            menu.findItem(R.id.action_remove_language).setVisible(mUsedLocaleNames.length > 1);
+        }
     }
 
     /**
@@ -274,6 +278,7 @@ public final class LanguagesSettingsFragment extends PreferenceFragment {
                         }
 
                         // refresh the list of enabled languages
+                        getActivity().invalidateOptionsMenu();
                         buildContent();
                     }
                 })
@@ -333,6 +338,7 @@ public final class LanguagesSettingsFragment extends PreferenceFragment {
                         }
 
                         // refresh the list of enabled languages
+                        getActivity().invalidateOptionsMenu();
                         buildContent();
                     }
                 })

--- a/app/src/main/java/rkr/simplekeyboard/inputmethod/latin/settings/LanguagesSettingsFragment.java
+++ b/app/src/main/java/rkr/simplekeyboard/inputmethod/latin/settings/LanguagesSettingsFragment.java
@@ -137,8 +137,7 @@ public final class LanguagesSettingsFragment extends PreferenceFragment {
         final SortedSet<Locale> unusedLocales = getUnusedLocales(usedLocales, comparator);
 
         buildLanguagePreferences(usedLocales, group, context);
-        setAdditionalLocaleEntries(unusedLocales);
-        setExistingLocaleEntries(usedLocales);
+        setLocaleEntries(usedLocales, unusedLocales);
     }
 
     /**
@@ -201,34 +200,30 @@ public final class LanguagesSettingsFragment extends PreferenceFragment {
     }
 
     /**
-     * Set the list of unused languages that can be added.
-     * @param locales the unused locales that are supported in this IME.
+     * Set the lists of used languages that can be removed and unused languages that can be added.
+     * @param usedLocales the enabled locales for this IME.
+     * @param unusedLocales the unused locales that are supported in this IME.
      */
-    private void setAdditionalLocaleEntries(final SortedSet<Locale> locales) {
-        mUnusedLocaleNames = new CharSequence[locales.size()];
-        mUnusedLocaleValues = new String[locales.size()];
+    private void setLocaleEntries(final SortedSet<Locale> usedLocales,
+                                  final SortedSet<Locale> unusedLocales) {
+        mUsedLocaleNames = new CharSequence[usedLocales.size()];
+        mUsedLocaleValues = new String[usedLocales.size()];
         int i = 0;
-        for (Locale locale : locales) {
-            final String localeString = LocaleUtils.getLocaleString(locale);
-            mUnusedLocaleValues[i] = localeString;
-            mUnusedLocaleNames[i] =
-                    LocaleResourceUtils.getLocaleDisplayNameInSystemLocale(localeString);
-            i++;
-        }
-    }
-
-    /**
-     * Set the list of used languages that can be removed.
-     * @param locales the enabled locales for this IME.
-     */
-    private void setExistingLocaleEntries(final SortedSet<Locale> locales) {
-        mUsedLocaleNames = new CharSequence[locales.size()];
-        mUsedLocaleValues = new String[locales.size()];
-        int i = 0;
-        for (Locale locale : locales) {
+        for (Locale locale : usedLocales) {
             final String localeString = LocaleUtils.getLocaleString(locale);
             mUsedLocaleValues[i] = localeString;
             mUsedLocaleNames[i] =
+                    LocaleResourceUtils.getLocaleDisplayNameInSystemLocale(localeString);
+            i++;
+        }
+
+        mUnusedLocaleNames = new CharSequence[unusedLocales.size()];
+        mUnusedLocaleValues = new String[unusedLocales.size()];
+        i = 0;
+        for (Locale locale : unusedLocales) {
+            final String localeString = LocaleUtils.getLocaleString(locale);
+            mUnusedLocaleValues[i] = localeString;
+            mUnusedLocaleNames[i] =
                     LocaleResourceUtils.getLocaleDisplayNameInSystemLocale(localeString);
             i++;
         }
@@ -293,6 +288,9 @@ public final class LanguagesSettingsFragment extends PreferenceFragment {
         mAlertDialog.getButton(AlertDialog.BUTTON_POSITIVE).setEnabled(false);
     }
 
+    /**
+     * Show the popup to remove an existing language.
+     */
     private void showRemoveLanguagePopup() {
         final boolean[] checkedItems = new boolean[mUsedLocaleNames.length];
         mAlertDialog = new AlertDialog.Builder(getActivity())
@@ -326,7 +324,6 @@ public final class LanguagesSettingsFragment extends PreferenceFragment {
                     public void onClick(final DialogInterface dialog, final int which) {
                         // disable the layouts for all of the checked languages
                         for (int i = 0; i < checkedItems.length; i++) {
-                            Log.w(TAG, mUsedLocaleNames[i] + ": " + checkedItems[i]);
                             if (!checkedItems[i]) {
                                 continue;
                             }

--- a/app/src/main/java/rkr/simplekeyboard/inputmethod/latin/settings/SingleLanguageSettingsFragment.java
+++ b/app/src/main/java/rkr/simplekeyboard/inputmethod/latin/settings/SingleLanguageSettingsFragment.java
@@ -23,19 +23,12 @@ import android.preference.PreferenceCategory;
 import android.preference.PreferenceFragment;
 import android.preference.PreferenceGroup;
 import android.preference.SwitchPreference;
-import android.view.LayoutInflater;
-import android.view.Menu;
-import android.view.MenuInflater;
-import android.view.MenuItem;
-import android.view.View;
-import android.view.ViewGroup;
 import android.widget.Toast;
 
 import java.util.List;
 import java.util.Set;
 
 import rkr.simplekeyboard.inputmethod.R;
-import rkr.simplekeyboard.inputmethod.compat.MenuItemIconColorCompat;
 import rkr.simplekeyboard.inputmethod.latin.Subtype;
 import rkr.simplekeyboard.inputmethod.latin.RichInputMethodManager;
 import rkr.simplekeyboard.inputmethod.latin.utils.LocaleResourceUtils;
@@ -49,7 +42,6 @@ public final class SingleLanguageSettingsFragment extends PreferenceFragment {
     public static final String LOCALE_BUNDLE_KEY = "LOCALE";
 
     private RichInputMethodManager mRichImm;
-    private View mView;
 
     @Override
     public void onCreate(final Bundle icicle) {
@@ -58,42 +50,6 @@ public final class SingleLanguageSettingsFragment extends PreferenceFragment {
         RichInputMethodManager.init(getActivity());
         mRichImm = RichInputMethodManager.getInstance();
         addPreferencesFromResource(R.xml.empty_settings);
-
-        setHasOptionsMenu(true);
-    }
-
-    @Override
-    public View onCreateView(final LayoutInflater inflater, final ViewGroup container,
-                             final Bundle savedInstanceState) {
-        mView = super.onCreateView(inflater, container, savedInstanceState);
-        return mView;
-    }
-
-    @Override
-    public void onCreateOptionsMenu(final Menu menu, final MenuInflater inflater) {
-        inflater.inflate(R.menu.remove_language, menu);
-
-        MenuItem menuItem = menu.findItem(R.id.action_remove_language);
-        MenuItemIconColorCompat.matchMenuIconColor(mView, menuItem, getActivity().getActionBar());
-    }
-
-    @Override
-    public boolean onOptionsItemSelected(final MenuItem item) {
-        final int itemId = item.getItemId();
-        if (itemId == R.id.action_remove_language) {
-            if (mRichImm.getEnabledLocales().size() <= 1) {
-                Toast.makeText(SingleLanguageSettingsFragment.this.getActivity(),
-                        R.string.layout_not_disabled, Toast.LENGTH_SHORT).show();
-                return false;
-            }
-            final String locale = getArguments().getString(LOCALE_BUNDLE_KEY);
-            for (Subtype subtype: mRichImm.getEnabledSubtypesForLocale(locale)) {
-                if (!mRichImm.removeSubtype(subtype))
-                    return false;
-            }
-            getActivity().onBackPressed();
-        }
-        return super.onOptionsItemSelected(item);
     }
 
     @Override
@@ -170,15 +126,15 @@ public final class SingleLanguageSettingsFragment extends PreferenceFragment {
                 }
                 final boolean isEnabling = (boolean)newValue;
                 final SubtypePreference pref = (SubtypePreference) preference;
-                final String locale = getArguments().getString(LOCALE_BUNDLE_KEY);
                 if (isEnabling) {
                     return mRichImm.addSubtype(pref.getSubtype());
-                } else if (mRichImm.getEnabledSubtypesForLocale(locale).size() > 1) {
-                    return mRichImm.removeSubtype(pref.getSubtype());
                 } else {
-                    Toast.makeText(SingleLanguageSettingsFragment.this.getActivity(),
-                            R.string.layout_not_disabled, Toast.LENGTH_SHORT).show();
-                    return false;
+                    final boolean removed = mRichImm.removeSubtype(pref.getSubtype());
+                    if (!removed) {
+                        Toast.makeText(SingleLanguageSettingsFragment.this.getActivity(),
+                                R.string.layout_not_disabled, Toast.LENGTH_SHORT).show();
+                    }
+                    return removed;
                 }
             }
         });

--- a/app/src/main/java/rkr/simplekeyboard/inputmethod/latin/settings/SingleLanguageSettingsFragment.java
+++ b/app/src/main/java/rkr/simplekeyboard/inputmethod/latin/settings/SingleLanguageSettingsFragment.java
@@ -158,7 +158,8 @@ public final class SingleLanguageSettingsFragment extends PreferenceFragment {
                 final SubtypePreference pref = (SubtypePreference) preference;
                 if (isEnabling) {
                     final boolean added = mRichImm.addSubtype(pref.getSubtype());
-                    // remove the subtype that is pending to be removed (already unchecked)
+                    // remove the subtype that is pending to be removed (already unchecked) if it
+                    // isn't getting re-enabled now
                     if (added && mSubtypeToRemove != null
                             && (mSubtypeToRemove.equals(pref.getSubtype())
                             || mRichImm.removeSubtype(mSubtypeToRemove))) {

--- a/app/src/main/res/values-af/strings.xml
+++ b/app/src/main/res/values-af/strings.xml
@@ -38,6 +38,7 @@
     <string name="subtype_traditional">"Tradisioneel"</string>
     <string name="subtype_compact">"Kompak"</string>
     <string name="add">"Voeg by"</string>
+    <string name="remove">"Verwyder"</string>
     <string name="prefs_keypress_vibration_duration_settings">"Sleuteldruk se vibrasie-tydsduur"</string>
     <string name="prefs_keypress_sound_volume_settings">"Sleuteldruk se klankvolume"</string>
     <string name="prefs_key_longpress_timeout_settings">"Vertraging van sleutellangdruk"</string>

--- a/app/src/main/res/values-am/strings.xml
+++ b/app/src/main/res/values-am/strings.xml
@@ -38,6 +38,7 @@
     <string name="subtype_traditional">"ተለምዷዊ"</string>
     <string name="subtype_compact">"እስግ"</string>
     <string name="add">"አክል"</string>
+    <string name="remove">"አስወግድ"</string>
     <string name="prefs_keypress_vibration_duration_settings">"የቁልፍ ጭነት ንዝረት ርዝመት"</string>
     <string name="prefs_keypress_sound_volume_settings">"የቁልፍ ጭነት ድምጽ መጠን"</string>
     <string name="prefs_key_longpress_timeout_settings">"የሰሌዳ ቁልፍ ጠቅታ በመጫን መዘግየት"</string>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -38,6 +38,7 @@
     <string name="subtype_traditional">"التقليدية"</string>
     <string name="subtype_compact">"مكثفة"</string>
     <string name="add">"إضافة"</string>
+    <string name="remove">"إزالة"</string>
     <string name="prefs_keypress_vibration_duration_settings">"مدة اهتزاز الضغط على المفاتيح"</string>
     <string name="prefs_keypress_sound_volume_settings">"مستوى صوت الضغط على المفاتيح"</string>
     <string name="prefs_key_longpress_timeout_settings">"تأخير الضغط الطويل للمفاتيح"</string>

--- a/app/src/main/res/values-az-rAZ/strings.xml
+++ b/app/src/main/res/values-az-rAZ/strings.xml
@@ -38,6 +38,7 @@
     <string name="subtype_traditional">"Ənənəvi"</string>
     <string name="subtype_compact">"Kompakt"</string>
     <string name="add">"Əlavə et"</string>
+    <string name="remove">"Ləğv et"</string>
     <string name="prefs_keypress_vibration_duration_settings">"Vibrasiyalı klikləmə müddəti"</string>
     <string name="prefs_keypress_sound_volume_settings">"Səsli klikləmə səsi"</string>
     <string name="prefs_key_longpress_timeout_settings">"Klavişi uzun müddət basmada gecikmə"</string>

--- a/app/src/main/res/values-b+sr+Latn/strings.xml
+++ b/app/src/main/res/values-b+sr+Latn/strings.xml
@@ -38,6 +38,7 @@
     <string name="subtype_traditional">"tradicionalni"</string>
     <string name="subtype_compact">"kompaktna"</string>
     <string name="add">"Dodaj"</string>
+    <string name="remove">"Ukloni"</string>
     <string name="prefs_keypress_vibration_duration_settings">"Trajanje vibracije pri pritisku"</string>
     <string name="prefs_keypress_sound_volume_settings">"Jačina zvuka pri pritisku"</string>
     <string name="prefs_key_longpress_timeout_settings">"Odlaganje pri dugom pritisku"</string>

--- a/app/src/main/res/values-be-rBY/strings.xml
+++ b/app/src/main/res/values-be-rBY/strings.xml
@@ -38,6 +38,7 @@
     <string name="subtype_traditional">"традыцыйная"</string>
     <string name="subtype_compact">"кампактная"</string>
     <string name="add">"Дадаць"</string>
+    <string name="remove">"Выдаліць"</string>
     <string name="prefs_keypress_vibration_duration_settings">"Працягласць вібрацыі пры націску клавіш"</string>
     <string name="prefs_keypress_sound_volume_settings">"Гучнасць гуку пры націску клавіш"</string>
     <string name="prefs_key_longpress_timeout_settings">"Затрымка доўгага націску клавішы"</string>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -39,6 +39,7 @@
     <string name="subtype_compact">"компактна"</string>
     <string name="subtype_bds">"БДС"</string>
     <string name="add">"Добавяне"</string>
+    <string name="remove">"Премахване"</string>
     <string name="prefs_keypress_vibration_duration_settings">"Продълж. на вибриране при натискане"</string>
     <string name="prefs_keypress_sound_volume_settings">"Сила на звука при натиск. на клавиш"</string>
     <string name="prefs_key_longpress_timeout_settings">"Забавяне при продълж. натискане"</string>

--- a/app/src/main/res/values-bn-rBD/strings.xml
+++ b/app/src/main/res/values-bn-rBD/strings.xml
@@ -38,6 +38,7 @@
     <string name="subtype_traditional">"ঐতিহ্যবাহি"</string>
     <string name="subtype_compact">"কম্প্যাক্ট"</string>
     <string name="add">"জুড়ুন"</string>
+    <string name="remove">"সরান"</string>
     <string name="prefs_keypress_vibration_duration_settings">"কীপ্রেস কম্পন সময়কাল"</string>
     <string name="prefs_keypress_sound_volume_settings">"কীপ্রেস সাউন্ড ভলিউম"</string>
     <string name="prefs_key_longpress_timeout_settings">"কী প্রেসে দীর্ঘ বিলম্ব"</string>

--- a/app/src/main/res/values-bs-rBA/strings.xml
+++ b/app/src/main/res/values-bs-rBA/strings.xml
@@ -38,6 +38,7 @@
     <string name="subtype_traditional">"tradicionalan"</string>
     <string name="subtype_compact">"kompaktan"</string>
     <string name="add">"Dodaj"</string>
+    <string name="remove">"Ukloni"</string>
     <string name="prefs_keypress_vibration_duration_settings">"Trajanje vibracije pritisnute tipke"</string>
     <string name="prefs_keypress_sound_volume_settings">"Jačina zvuka pritisnute tipke"</string>
     <string name="prefs_key_longpress_timeout_settings">"Odgoda dugog pritiska tipke"</string>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -38,6 +38,7 @@
     <string name="subtype_traditional">"tradicional"</string>
     <string name="subtype_compact">"compacte"</string>
     <string name="add">"Afegeix"</string>
+    <string name="remove">"Elimina"</string>
     <string name="prefs_keypress_vibration_duration_settings">"Durada vibració en prémer"</string>
     <string name="prefs_keypress_sound_volume_settings">"Volum so en prémer tecla"</string>
     <string name="prefs_key_longpress_timeout_settings">"Retard en mantenir premut"</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -38,6 +38,7 @@
     <string name="subtype_traditional">"tradiční"</string>
     <string name="subtype_compact">"kompaktní"</string>
     <string name="add">"Přidat"</string>
+    <string name="remove">"Odebrat"</string>
     <string name="prefs_keypress_vibration_duration_settings">"Délka vibrace při stisknutí klávesy"</string>
     <string name="prefs_keypress_sound_volume_settings">"Hlasitost stisknutí klávesy"</string>
     <string name="prefs_key_longpress_timeout_settings">"Prodleva dlouhého stisknutí"</string>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -38,6 +38,7 @@
     <string name="subtype_traditional">"traditionelt"</string>
     <string name="subtype_compact">"kompakt"</string>
     <string name="add">"Tilføj"</string>
+    <string name="remove">"Fjern"</string>
     <string name="prefs_keypress_vibration_duration_settings">"Vibrationstid ved tastetryk"</string>
     <string name="prefs_keypress_sound_volume_settings">"Lydstyrke ved tastetryk"</string>
     <string name="prefs_key_longpress_timeout_settings">"Forsinket langt tastetryk"</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -38,6 +38,7 @@
     <string name="subtype_traditional">"traditionell"</string>
     <string name="subtype_compact">"kompakt"</string>
     <string name="add">"Hinzufügen"</string>
+    <string name="remove">"Entfernen"</string>
     <string name="prefs_keypress_vibration_duration_settings">"Vibrationsdauer bei Tastendruck"</string>
     <string name="prefs_keypress_sound_volume_settings">"Tonlautstärke bei Tastendruck"</string>
     <string name="prefs_key_longpress_timeout_settings">"Verzögerung für langes Drücken"</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -38,6 +38,7 @@
     <string name="subtype_traditional">"Παραδοσιακά"</string>
     <string name="subtype_compact">"Συμπαγές"</string>
     <string name="add">"Προσθήκη"</string>
+    <string name="remove">"Κατάργηση"</string>
     <string name="prefs_keypress_vibration_duration_settings">"Διάρκεια δόνησης πατήμ. πλήκτ."</string>
     <string name="prefs_keypress_sound_volume_settings">"Ένταση ήχου πατήματος πλήκτρου"</string>
     <string name="prefs_key_longpress_timeout_settings">"Καθυστέρηση παρατεταμένου πατήματος"</string>

--- a/app/src/main/res/values-es-rUS/strings.xml
+++ b/app/src/main/res/values-es-rUS/strings.xml
@@ -38,6 +38,7 @@
     <string name="subtype_traditional">"tradicional"</string>
     <string name="subtype_compact">"compacto"</string>
     <string name="add">"Agregar"</string>
+    <string name="remove">"Eliminar"</string>
     <string name="prefs_keypress_vibration_duration_settings">"Duración de la vibración"</string>
     <string name="prefs_keypress_sound_volume_settings">"Volumen al presionar teclas"</string>
     <string name="prefs_key_longpress_timeout_settings">"Demora al mantener presionado"</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -38,6 +38,7 @@
     <string name="subtype_traditional">"tradicional"</string>
     <string name="subtype_compact">"compacto"</string>
     <string name="add">"Añadir"</string>
+    <string name="remove">"Quitar"</string>
     <string name="prefs_keypress_vibration_duration_settings">"Duración de la vibración al pulsar"</string>
     <string name="prefs_keypress_sound_volume_settings">"Volumen de sonido al pulsar tecla"</string>
     <string name="prefs_key_longpress_timeout_settings">"Retraso al mantener pulsado"</string>

--- a/app/src/main/res/values-et-rEE/strings.xml
+++ b/app/src/main/res/values-et-rEE/strings.xml
@@ -38,6 +38,7 @@
     <string name="subtype_traditional">"traditsiooniline"</string>
     <string name="subtype_compact">"kompaktne"</string>
     <string name="add">"Lisa"</string>
+    <string name="remove">"Eemalda"</string>
     <string name="prefs_keypress_vibration_duration_settings">"Klahvivajutuse vibreerimise kestus"</string>
     <string name="prefs_keypress_sound_volume_settings">"Klahvivajutuse helitugevus"</string>
     <string name="prefs_key_longpress_timeout_settings">"Pika klahvivajutuse viide"</string>

--- a/app/src/main/res/values-eu-rES/strings.xml
+++ b/app/src/main/res/values-eu-rES/strings.xml
@@ -38,6 +38,7 @@
     <string name="subtype_traditional">"tradizionala"</string>
     <string name="subtype_compact">"trinkoa"</string>
     <string name="add">"Gehitu"</string>
+    <string name="remove">"Kendu"</string>
     <string name="prefs_keypress_vibration_duration_settings">"Tekla sakatzearen dardararen iraupena"</string>
     <string name="prefs_keypress_sound_volume_settings">"Tekla sakatzearen bolumena"</string>
     <string name="prefs_key_longpress_timeout_settings">"Luze sakatzearen atzerapena"</string>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -38,6 +38,7 @@
     <string name="subtype_traditional">"سنتی"</string>
     <string name="subtype_compact">"فشرده"</string>
     <string name="add">"افزودن"</string>
+    <string name="remove">"حذف"</string>
     <string name="prefs_keypress_vibration_duration_settings">"طول مدت لرزش در اثر فشردن کلید"</string>
     <string name="prefs_keypress_sound_volume_settings">"میزان صدای فشردن کلید"</string>
     <string name="prefs_key_longpress_timeout_settings">"تأخیر فشار طولانی کلید"</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -38,6 +38,7 @@
     <string name="subtype_traditional">"perinteinen"</string>
     <string name="subtype_compact">"tiivis"</string>
     <string name="add">"Lisää"</string>
+    <string name="remove">"Poista"</string>
     <string name="prefs_keypress_vibration_duration_settings">"Painalluksen värinän kesto"</string>
     <string name="prefs_keypress_sound_volume_settings">"Näppäinpainalluksen äänenvoimakkuus"</string>
     <string name="prefs_key_longpress_timeout_settings">"Pitkän painalluksen viive"</string>

--- a/app/src/main/res/values-fr-rCA/strings.xml
+++ b/app/src/main/res/values-fr-rCA/strings.xml
@@ -38,6 +38,7 @@
     <string name="subtype_traditional">"traditionnel"</string>
     <string name="subtype_compact">"compact"</string>
     <string name="add">"Ajouter"</string>
+    <string name="remove">"Supprimer"</string>
     <string name="prefs_keypress_vibration_duration_settings">"Durée vibration press. touche"</string>
     <string name="prefs_keypress_sound_volume_settings">"Volume pression de touche"</string>
     <string name="prefs_key_longpress_timeout_settings">"Délai appui prolongé sur touche"</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -38,6 +38,7 @@
     <string name="subtype_traditional">"traditionnel"</string>
     <string name="subtype_compact">"Compact"</string>
     <string name="add">"Ajouter"</string>
+    <string name="remove">"Supprimer"</string>
     <string name="prefs_keypress_vibration_duration_settings">"Durée de vibration des touches"</string>
     <string name="prefs_keypress_sound_volume_settings">"Volume son pression de touche"</string>
     <string name="prefs_key_longpress_timeout_settings">"Délai d\'appui prolongé"</string>

--- a/app/src/main/res/values-gl-rES/strings.xml
+++ b/app/src/main/res/values-gl-rES/strings.xml
@@ -38,6 +38,7 @@
     <string name="subtype_traditional">"tradicional"</string>
     <string name="subtype_compact">"compacto"</string>
     <string name="add">"Engadir"</string>
+    <string name="remove">"Eliminar"</string>
     <string name="prefs_keypress_vibration_duration_settings">"Duración vibración ao premer teclas"</string>
     <string name="prefs_keypress_sound_volume_settings">"Volume do son ao premer teclas"</string>
     <string name="prefs_key_longpress_timeout_settings">"Retraso de pulsación prolongada"</string>

--- a/app/src/main/res/values-gu-rIN/strings.xml
+++ b/app/src/main/res/values-gu-rIN/strings.xml
@@ -38,6 +38,7 @@
     <string name="subtype_traditional">"પરંપરાગત"</string>
     <string name="subtype_compact">"કોમ્પેક્ટ"</string>
     <string name="add">"ઉમેરો"</string>
+    <string name="remove">"દૂર કરો"</string>
     <string name="prefs_keypress_vibration_duration_settings">"કીપ્રેસ વાઇબ્રેશન અવધિ"</string>
     <string name="prefs_keypress_sound_volume_settings">"કીપ્રેસ ધ્વનિ વોલ્યુમ"</string>
     <string name="prefs_key_longpress_timeout_settings">"લાંબા કી પ્રેસનો વિલંબ"</string>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -38,6 +38,7 @@
     <string name="subtype_traditional">"पारंपरिक"</string>
     <string name="subtype_compact">"संक्षिप्त"</string>
     <string name="add">"जोड़ें"</string>
+    <string name="remove">"निकालें"</string>
     <string name="prefs_keypress_vibration_duration_settings">"बटन दबाने पर कंपन अवधि"</string>
     <string name="prefs_keypress_sound_volume_settings">"बटन दबाने पर आवाज़ का स्तर"</string>
     <string name="prefs_key_longpress_timeout_settings">"बटन दबाए रखने की समयाविधि"</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -38,6 +38,7 @@
     <string name="subtype_traditional">"tradicionalni"</string>
     <string name="subtype_compact">"kompaktna"</string>
     <string name="add">"Dodaj"</string>
+    <string name="remove">"Ukloni"</string>
     <string name="prefs_keypress_vibration_duration_settings">"Trajanje vibracije pritiska"</string>
     <string name="prefs_keypress_sound_volume_settings">"Glasnoća pritiska tipke"</string>
     <string name="prefs_key_longpress_timeout_settings">"Trajanje dugog pritiska tipke"</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -38,6 +38,7 @@
     <string name="subtype_traditional">"hagyományos"</string>
     <string name="subtype_compact">"kompakt"</string>
     <string name="add">"Hozzáadás"</string>
+    <string name="remove">"Eltávolítás"</string>
     <string name="prefs_keypress_vibration_duration_settings">"Gombnyomás rezgési időtartama"</string>
     <string name="prefs_keypress_sound_volume_settings">"Gombnyomás hangereje"</string>
     <string name="prefs_key_longpress_timeout_settings">"Hosszú nyomás késleltetése"</string>

--- a/app/src/main/res/values-hy-rAM/strings.xml
+++ b/app/src/main/res/values-hy-rAM/strings.xml
@@ -38,6 +38,7 @@
     <string name="subtype_traditional">"ավանդական"</string>
     <string name="subtype_compact">"սեղմ"</string>
     <string name="add">"Ավելացնել"</string>
+    <string name="remove">"Հեռացնել"</string>
     <string name="prefs_keypress_vibration_duration_settings">"Սեղմման թրթռոցի տևողություն"</string>
     <string name="prefs_keypress_sound_volume_settings">"Սեղմման ձայնի բարձրությունը"</string>
     <string name="prefs_key_longpress_timeout_settings">"Ստեղնի երկար սեղմման ուշացում"</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -39,6 +39,7 @@
     <string name="subtype_traditional">"Tradisional"</string>
     <string name="subtype_compact">"Rapat"</string>
     <string name="add">"Tambahkan"</string>
+    <string name="remove">"Hapus"</string>
     <string name="prefs_keypress_vibration_duration_settings">"Durasi getar saat tekan tombol"</string>
     <string name="prefs_keypress_sound_volume_settings">"Volume suara saat tekan tombol"</string>
     <string name="prefs_key_longpress_timeout_settings">"Penundaan tekan lama tombol"</string>

--- a/app/src/main/res/values-is-rIS/strings.xml
+++ b/app/src/main/res/values-is-rIS/strings.xml
@@ -38,6 +38,7 @@
     <string name="subtype_traditional">"hefðbundið"</string>
     <string name="subtype_compact">"lítið"</string>
     <string name="add">"Bæta við"</string>
+    <string name="remove">"Fjarlægja"</string>
     <string name="prefs_keypress_vibration_duration_settings">"Lengd lyklatitrings"</string>
     <string name="prefs_keypress_sound_volume_settings">"Styrkur lyklahljóða"</string>
     <string name="prefs_key_longpress_timeout_settings">"Töf áður en lykli er haldið inni"</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -38,6 +38,7 @@
     <string name="subtype_traditional">"tradizionale"</string>
     <string name="subtype_compact">"compatto"</string>
     <string name="add">"Aggiungi"</string>
+    <string name="remove">"Rimuovi"</string>
     <string name="prefs_keypress_vibration_duration_settings">"Durata vibrazione pressione tasto"</string>
     <string name="prefs_keypress_sound_volume_settings">"Volume audio a pressione tasto"</string>
     <string name="prefs_key_longpress_timeout_settings">"Ritardo pressione lunga tasti"</string>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -38,6 +38,7 @@
     <string name="subtype_traditional">"מסורתית"</string>
     <string name="subtype_compact">"קומפקטית"</string>
     <string name="add">"הוסף"</string>
+    <string name="remove">"הסר"</string>
     <string name="prefs_keypress_vibration_duration_settings">"משך רטט של לחיצת מקש"</string>
     <string name="prefs_keypress_sound_volume_settings">"עוצמת קול של לחיצת מקש"</string>
     <string name="prefs_key_longpress_timeout_settings">"השהיית לחיצה ארוכה על מקש"</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -38,6 +38,7 @@
     <string name="subtype_traditional">"伝統言語"</string>
     <string name="subtype_compact">"コンパクト"</string>
     <string name="add">"追加"</string>
+    <string name="remove">"削除"</string>
     <string name="prefs_keypress_vibration_duration_settings">"キー操作バイブの振動時間"</string>
     <string name="prefs_keypress_sound_volume_settings">"キー操作音の音量"</string>
     <string name="prefs_key_longpress_timeout_settings">"キーの長押し時間"</string>

--- a/app/src/main/res/values-ka-rGE/strings.xml
+++ b/app/src/main/res/values-ka-rGE/strings.xml
@@ -38,6 +38,7 @@
     <string name="subtype_traditional">"ტრადიციული"</string>
     <string name="subtype_compact">"კომპაქტური"</string>
     <string name="add">"დამატება"</string>
+    <string name="remove">"ამოშლა"</string>
     <string name="prefs_keypress_vibration_duration_settings">"კლავიშზე დაჭერის ვიბრაციის ხანგრძლივობა"</string>
     <string name="prefs_keypress_sound_volume_settings">"კლავიშზე დაჭერის ხმა"</string>
     <string name="prefs_key_longpress_timeout_settings">"კლავიშზე გრძელი დაჭერის დაყოვნება"</string>

--- a/app/src/main/res/values-kk-rKZ/strings.xml
+++ b/app/src/main/res/values-kk-rKZ/strings.xml
@@ -38,6 +38,7 @@
     <string name="subtype_traditional">"дәстүрлі"</string>
     <string name="subtype_compact">"шағын"</string>
     <string name="add">"Қосу"</string>
+    <string name="remove">"Өшіру"</string>
     <string name="prefs_keypress_vibration_duration_settings">"Пернені басқан кездегі діріл ұзақтығы"</string>
     <string name="prefs_keypress_sound_volume_settings">"Пернені басқан кездегі дыбыс деңгейі"</string>
     <string name="prefs_key_longpress_timeout_settings">"Пернені ұзақ басу кідірісі"</string>

--- a/app/src/main/res/values-km-rKH/strings.xml
+++ b/app/src/main/res/values-km-rKH/strings.xml
@@ -38,6 +38,7 @@
     <string name="subtype_traditional">"អក្សរ​ពេញ"</string>
     <string name="subtype_compact">"បង្រួម"</string>
     <string name="add">"បន្ថែម"</string>
+    <string name="remove">"លុប​ចេញ"</string>
     <string name="prefs_keypress_vibration_duration_settings">"ថិរវេលា​​ញ័រ​​ពេល​ចុច​គ្រាប់ចុច"</string>
     <string name="prefs_keypress_sound_volume_settings">"កម្រិត​សំឡេង​ពេល​ចុច​គ្រាប់​ចុច"</string>
     <string name="prefs_key_longpress_timeout_settings">"ពន្យារពេល​​​ចុច​គ្រាប់​ចុច​ឲ្យ​​យូរ"</string>

--- a/app/src/main/res/values-kn-rIN/strings.xml
+++ b/app/src/main/res/values-kn-rIN/strings.xml
@@ -38,6 +38,7 @@
     <string name="subtype_traditional">"ಸಾಂಪ್ರದಾಯಿಕ"</string>
     <string name="subtype_compact">"ಕಾಂಪ್ಯಾಕ್ಟ್‌‌"</string>
     <string name="add">"ಸೇರಿಸು"</string>
+    <string name="remove">"ತೆಗೆದುಹಾಕಿ"</string>
     <string name="prefs_keypress_vibration_duration_settings">"ಕೀಒತ್ತುವ ವೈಬ್ರೇಷನ್‌‌ ಅವಧಿ"</string>
     <string name="prefs_keypress_sound_volume_settings">"ಕೀಒತ್ತುವ ಶಬ್ದದ ವಾಲ್ಯೂಮ್"</string>
     <string name="prefs_key_longpress_timeout_settings">"ಕೀಯ ದೀರ್ಘ ಒತ್ತುವ ವಿಳಂಬ"</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -38,6 +38,7 @@
     <string name="subtype_traditional">"번체"</string>
     <string name="subtype_compact">"컴팩트"</string>
     <string name="add">"추가"</string>
+    <string name="remove">"삭제"</string>
     <string name="prefs_keypress_vibration_duration_settings">"키를 누를 때 진동 시간"</string>
     <string name="prefs_keypress_sound_volume_settings">"키를 누를 때 소리 볼륨"</string>
     <string name="prefs_key_longpress_timeout_settings">"키 길게 누르기 지연"</string>

--- a/app/src/main/res/values-ky-rKG/strings.xml
+++ b/app/src/main/res/values-ky-rKG/strings.xml
@@ -38,6 +38,7 @@
     <string name="subtype_traditional">"Салттык"</string>
     <string name="subtype_compact">"Чакан"</string>
     <string name="add">"Кошуу"</string>
+    <string name="remove">"Алып салуу"</string>
     <string name="prefs_keypress_vibration_duration_settings">"Басылган баскычтын дирлдөө узактгы"</string>
     <string name="prefs_keypress_sound_volume_settings">"Басылган баскычтын үнүнүн катуулугу"</string>
     <string name="prefs_key_longpress_timeout_settings">"Баскычты көпкө басуунун узактыгы"</string>

--- a/app/src/main/res/values-lo-rLA/strings.xml
+++ b/app/src/main/res/values-lo-rLA/strings.xml
@@ -38,6 +38,7 @@
     <string name="subtype_traditional">"ດັ້ງ​ເດີມ"</string>
     <string name="subtype_compact">"ກະ​ທັດ​ຮັດ"</string>
     <string name="add">"ເພີ່ມ"</string>
+    <string name="remove">"ລຶບອອກ"</string>
     <string name="prefs_keypress_vibration_duration_settings">"ໄລຍະເວລາຂອງການສັ່ນໃນການກົດປຸ່ມ"</string>
     <string name="prefs_keypress_sound_volume_settings">"ລະດັບສຽງຂອງການກົດປຸ່ມ"</string>
     <string name="prefs_key_longpress_timeout_settings">"ໄລຍະເວລາຂອງການກົດປຸ່ມ"</string>

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -39,6 +39,7 @@
     <string name="subtype_traditional">"tradicinė"</string>
     <string name="subtype_compact">"kompaktiška"</string>
     <string name="add">"Pridėti"</string>
+    <string name="remove">"Pašalinti"</string>
     <string name="prefs_keypress_vibration_duration_settings">"Vibrav. paspaudus mygt. trukmė"</string>
     <string name="prefs_keypress_sound_volume_settings">"Garso paspaudus mygt. garsumas"</string>
     <string name="prefs_key_longpress_timeout_settings">"Klavišo ilgo paspaudimo delsa"</string>

--- a/app/src/main/res/values-lv/strings.xml
+++ b/app/src/main/res/values-lv/strings.xml
@@ -38,6 +38,7 @@
     <string name="subtype_traditional">"tradicionālā"</string>
     <string name="subtype_compact">"kompaktā"</string>
     <string name="add">"Pievienot"</string>
+    <string name="remove">"Noņemt"</string>
     <string name="prefs_keypress_vibration_duration_settings">"Taust. nosp. vibrācijas ilgums"</string>
     <string name="prefs_keypress_sound_volume_settings">"Taustiņu nosp. skaņas skaļums"</string>
     <string name="prefs_key_longpress_timeout_settings">"Taustiņa ilgās nosp. noildze"</string>

--- a/app/src/main/res/values-mk-rMK/strings.xml
+++ b/app/src/main/res/values-mk-rMK/strings.xml
@@ -38,6 +38,7 @@
     <string name="subtype_traditional">"традиционален"</string>
     <string name="subtype_compact">"Компактна"</string>
     <string name="add">"Додај"</string>
+    <string name="remove">"Отстрани"</string>
     <string name="prefs_keypress_vibration_duration_settings">"Траење на вибрација од копче"</string>
     <string name="prefs_keypress_sound_volume_settings">"Копче за јачина на звук"</string>
     <string name="prefs_key_longpress_timeout_settings">"Доцнење на долго притискање копче"</string>

--- a/app/src/main/res/values-ml-rIN/strings.xml
+++ b/app/src/main/res/values-ml-rIN/strings.xml
@@ -38,6 +38,7 @@
     <string name="subtype_traditional">"പരമ്പരാഗതം"</string>
     <string name="subtype_compact">"കോം‌പാക്‌ട്"</string>
     <string name="add">"ചേര്‍ക്കുക"</string>
+    <string name="remove">"നീക്കംചെയ്യുക"</string>
     <string name="prefs_keypress_vibration_duration_settings">"കീ അമർത്തുമ്പോഴുള്ള വൈബ്രേഷൻ ദൈർഘ്യം"</string>
     <string name="prefs_keypress_sound_volume_settings">"കീ അമർത്തുമ്പോഴുള്ള ശബ്‌ദ വോളിയം"</string>
     <string name="prefs_key_longpress_timeout_settings">"കീ അമർത്തിപ്പിടിക്കുന്നതിലെ കാലതാമസം"</string>

--- a/app/src/main/res/values-mn-rMN/strings.xml
+++ b/app/src/main/res/values-mn-rMN/strings.xml
@@ -38,6 +38,7 @@
     <string name="subtype_traditional">"уламжлалт"</string>
     <string name="subtype_compact">"Компакт"</string>
     <string name="add">"Нэмэх"</string>
+    <string name="remove">"Устгах"</string>
     <string name="prefs_keypress_vibration_duration_settings">"Товч дарах чичиргээний хугацаа"</string>
     <string name="prefs_keypress_sound_volume_settings">"Товчны дууны хэмжээ"</string>
     <string name="prefs_key_longpress_timeout_settings">"Товчны удаан даралтын тохиргоо"</string>

--- a/app/src/main/res/values-mr-rIN/strings.xml
+++ b/app/src/main/res/values-mr-rIN/strings.xml
@@ -38,6 +38,7 @@
     <string name="subtype_traditional">"पारंपारिक"</string>
     <string name="subtype_compact">"संक्षिप्त"</string>
     <string name="add">"जोडा"</string>
+    <string name="remove">"काढा"</string>
     <string name="prefs_keypress_vibration_duration_settings">"की दाबल्यावर कंपन कालावधी"</string>
     <string name="prefs_keypress_sound_volume_settings">"की दाबल्यावर आवाजाची तीव्रता"</string>
     <string name="prefs_key_longpress_timeout_settings">"की जास्त दाबण्यात विलंब"</string>

--- a/app/src/main/res/values-ms-rMY/strings.xml
+++ b/app/src/main/res/values-ms-rMY/strings.xml
@@ -38,6 +38,7 @@
     <string name="subtype_traditional">"Tradisional"</string>
     <string name="subtype_compact">"Sarat"</string>
     <string name="add">"Tambah"</string>
+    <string name="remove">"Alih Keluar"</string>
     <string name="prefs_keypress_vibration_duration_settings">"Tempoh getaran tekan kekunci"</string>
     <string name="prefs_keypress_sound_volume_settings">"Kelantangan bunyi tekan kekunci"</string>
     <string name="prefs_key_longpress_timeout_settings">"Lengah tekan lama kekunci"</string>

--- a/app/src/main/res/values-my-rMM/strings.xml
+++ b/app/src/main/res/values-my-rMM/strings.xml
@@ -38,6 +38,7 @@
     <string name="subtype_traditional">"ရိုးရာ"</string>
     <string name="subtype_compact">"ကျစ်လစ်သော"</string>
     <string name="add">"ထည့်ရန်"</string>
+    <string name="remove">"ဖယ်ရှားပါ"</string>
     <string name="prefs_keypress_vibration_duration_settings">"ခလုတ်နှိပ်တုန်ခါမှု ကြာမြင့်ချိန်"</string>
     <string name="prefs_keypress_sound_volume_settings">"ခလုတ်နှိပ်သည့် အသံအတိုးကျယ်"</string>
     <string name="prefs_key_longpress_timeout_settings">"ကီးကြာမြင့်စွာ ဖိနှိပ်မှုနှုန်း"</string>

--- a/app/src/main/res/values-nb/strings.xml
+++ b/app/src/main/res/values-nb/strings.xml
@@ -39,6 +39,7 @@
     <string name="subtype_traditional">"tradisjonelt"</string>
     <string name="subtype_compact">"kompakt"</string>
     <string name="add">"Legg til"</string>
+    <string name="remove">"Fjern"</string>
     <string name="prefs_keypress_vibration_duration_settings">"Vibrasjonstid ved tastetrykk"</string>
     <string name="prefs_keypress_sound_volume_settings">"Lydstyrke ved tastetrykk"</string>
     <string name="prefs_key_longpress_timeout_settings">"Forsinkelse ved lange tastetrykk"</string>

--- a/app/src/main/res/values-ne-rNP/strings.xml
+++ b/app/src/main/res/values-ne-rNP/strings.xml
@@ -38,6 +38,7 @@
     <string name="subtype_traditional">"परम्परागत"</string>
     <string name="subtype_compact">"संकुचित"</string>
     <string name="add">"थप्नुहोस्"</string>
+    <string name="remove">"हटाउनुहोस्"</string>
     <string name="prefs_keypress_vibration_duration_settings">"कुञ्जी थिचाइ भाइब्रेसन अवधि"</string>
     <string name="prefs_keypress_sound_volume_settings">"कुञ्जी थिचाइ आवाज भोल्युम"</string>
     <string name="prefs_key_longpress_timeout_settings">"कुञ्जीको लामो थिचाइमा ढिलाइ"</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -38,6 +38,7 @@
     <string name="subtype_traditional">"traditioneel"</string>
     <string name="subtype_compact">"compact"</string>
     <string name="add">"Toevoegen"</string>
+    <string name="remove">"Verwijderen"</string>
     <string name="prefs_keypress_vibration_duration_settings">"Trilingsduur bij toetsgebruik"</string>
     <string name="prefs_keypress_sound_volume_settings">"Geluidsvolume bij toetsgebruik"</string>
     <string name="prefs_key_longpress_timeout_settings">"Lengte toetsinvoer"</string>

--- a/app/src/main/res/values-pa-rIN/strings.xml
+++ b/app/src/main/res/values-pa-rIN/strings.xml
@@ -38,6 +38,7 @@
     <string name="subtype_traditional">"ਪਰੰਪਰਿਕ"</string>
     <string name="subtype_compact">"ਕੰਪੈਕਟ"</string>
     <string name="add">"ਜੋੜੋ"</string>
+    <string name="remove">"ਹਟਾਓ"</string>
     <string name="prefs_keypress_vibration_duration_settings">"ਕੀਪ੍ਰੈਸ ਵਾਈਬ੍ਰੇਸ਼ਨ ਮਿਆਦ"</string>
     <string name="prefs_keypress_sound_volume_settings">"ਕੀਪ੍ਰੈਸ ਅਵਾਜ਼ ਵੌਲਿਊਮ"</string>
     <string name="prefs_key_longpress_timeout_settings">"ਕੁੰਜੀ ਦਬਾਈ ਰੱਖਣ ਦੀ ਮਿਆਦ"</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -38,6 +38,7 @@
     <string name="subtype_traditional">"tradycyjny"</string>
     <string name="subtype_compact">"kompaktowa"</string>
     <string name="add">"Dodaj"</string>
+    <string name="remove">"Usuń"</string>
     <string name="prefs_keypress_vibration_duration_settings">"Wibracja przy naciśniętym klawiszu"</string>
     <string name="prefs_keypress_sound_volume_settings">"Głośność przy naciśniętym klawiszu"</string>
     <string name="prefs_key_longpress_timeout_settings">"Opóźnienie przy długim naciśnięciu"</string>

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -38,6 +38,7 @@
     <string name="subtype_traditional">"tradicional"</string>
     <string name="subtype_compact">"compacto"</string>
     <string name="add">"Adicionar"</string>
+    <string name="remove">"Remover"</string>
     <string name="prefs_keypress_vibration_duration_settings">"Duração vibr. ao premir teclas"</string>
     <string name="prefs_keypress_sound_volume_settings">"Volume do som ao premir teclas"</string>
     <string name="prefs_key_longpress_timeout_settings">"Atraso ao manter tecla premida"</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -39,6 +39,7 @@
     <string name="subtype_traditional">"tradicional"</string>
     <string name="subtype_compact">"compacto"</string>
     <string name="add">"Adicionar"</string>
+    <string name="remove">"Remover"</string>
     <string name="prefs_keypress_vibration_duration_settings">"Duração da vibração ao tocar"</string>
     <string name="prefs_keypress_sound_volume_settings">"Volume ao tocar na tela"</string>
     <string name="prefs_key_longpress_timeout_settings">"Atraso ao pressionar teclas"</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -38,6 +38,7 @@
     <string name="subtype_traditional">"tradițională"</string>
     <string name="subtype_compact">"Compact"</string>
     <string name="add">"Adăugați"</string>
+    <string name="remove">"Eliminați"</string>
     <string name="prefs_keypress_vibration_duration_settings">"Vibrare după apăsarea tastei"</string>
     <string name="prefs_keypress_sound_volume_settings">"Sunet la apăsarea tastelor"</string>
     <string name="prefs_key_longpress_timeout_settings">"Timpul apăsării lungi a tastei"</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -39,6 +39,7 @@
     <string name="subtype_traditional">"классическая"</string>
     <string name="subtype_compact">"компактная раскладка"</string>
     <string name="add">"Добавить"</string>
+    <string name="remove">"Удалить"</string>
     <string name="prefs_keypress_vibration_duration_settings">"Вибросигнал при нажатии клавиш"</string>
     <string name="prefs_keypress_sound_volume_settings">"Звук при нажатии клавиш"</string>
     <string name="prefs_key_longpress_timeout_settings">"Долгое нажатие"</string>

--- a/app/src/main/res/values-si-rLK/strings.xml
+++ b/app/src/main/res/values-si-rLK/strings.xml
@@ -38,6 +38,7 @@
     <string name="subtype_traditional">"සාම්ප්‍රදායික"</string>
     <string name="subtype_compact">"සංයුක්ත"</string>
     <string name="add">"එක් කරන්න"</string>
+    <string name="remove">"ඉවත් කරන්න"</string>
     <string name="prefs_keypress_vibration_duration_settings">"යතුරු එබිම් කම්පන කාලපරිච්ඡේදය"</string>
     <string name="prefs_keypress_sound_volume_settings">"යතුරු එබීම් හඬ තීව්‍රතාවය"</string>
     <string name="prefs_key_longpress_timeout_settings">"යතුරු දිගු එබීම් ප්‍රමාදය"</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -38,6 +38,7 @@
     <string name="subtype_traditional">"tradičná"</string>
     <string name="subtype_compact">"kompaktná"</string>
     <string name="add">"Pridať"</string>
+    <string name="remove">"Odstrániť"</string>
     <string name="prefs_keypress_vibration_duration_settings">"Dĺžka vibrácie klávesu"</string>
     <string name="prefs_keypress_sound_volume_settings">"Hlasitosť stlačenia klávesu"</string>
     <string name="prefs_key_longpress_timeout_settings">"Oneskorenie dlhého stlačenia"</string>

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -38,6 +38,7 @@
     <string name="subtype_traditional">"tradicionalna"</string>
     <string name="subtype_compact">"kompaktna"</string>
     <string name="add">"Dodaj"</string>
+    <string name="remove">"Odstrani"</string>
     <string name="prefs_keypress_vibration_duration_settings">"Trajanje vibr. ob prit. tipke"</string>
     <string name="prefs_keypress_sound_volume_settings">"Glasn. zvoka ob pritisku tipke"</string>
     <string name="prefs_key_longpress_timeout_settings">"Zakasn. za dolg pritisk tipke"</string>

--- a/app/src/main/res/values-sq-rAL/strings.xml
+++ b/app/src/main/res/values-sq-rAL/strings.xml
@@ -38,6 +38,7 @@
     <string name="subtype_traditional">"tradicionale"</string>
     <string name="subtype_compact">"kompakte"</string>
     <string name="add">"Shto"</string>
+    <string name="remove">"Hiq"</string>
     <string name="prefs_keypress_vibration_duration_settings">"Kohëzgjatja e dridhjes nga shtypja e tastit"</string>
     <string name="prefs_keypress_sound_volume_settings">"Volumi i tingullit të tastit"</string>
     <string name="prefs_key_longpress_timeout_settings">"Vonesa e shtypjes së gjatë të tastit"</string>

--- a/app/src/main/res/values-sr/strings.xml
+++ b/app/src/main/res/values-sr/strings.xml
@@ -38,6 +38,7 @@
     <string name="subtype_traditional">"традиционални"</string>
     <string name="subtype_compact">"компактна"</string>
     <string name="add">"Додај"</string>
+    <string name="remove">"Уклони"</string>
     <string name="prefs_keypress_vibration_duration_settings">"Трајање вибрације при притиску"</string>
     <string name="prefs_keypress_sound_volume_settings">"Јачина звука при притиску"</string>
     <string name="prefs_key_longpress_timeout_settings">"Одлагање при дугом притиску"</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -38,6 +38,7 @@
     <string name="subtype_traditional">"traditionell"</string>
     <string name="subtype_compact">"kompakt"</string>
     <string name="add">"Lägg till"</string>
+    <string name="remove">"Ta bort"</string>
     <string name="prefs_keypress_vibration_duration_settings">"Vibrationslängd för tangenter"</string>
     <string name="prefs_keypress_sound_volume_settings">"Ljudvolym för tangenter"</string>
     <string name="prefs_key_longpress_timeout_settings">"Fördröjning vid långt tryck"</string>

--- a/app/src/main/res/values-sw/strings.xml
+++ b/app/src/main/res/values-sw/strings.xml
@@ -38,6 +38,7 @@
     <string name="subtype_traditional">"cha Jadi"</string>
     <string name="subtype_compact">"Thabiti"</string>
     <string name="add">"Ongeza"</string>
+    <string name="remove">"Ondoa"</string>
     <string name="prefs_keypress_vibration_duration_settings">"Bonyeza kitufe cha muda wa kutetema"</string>
     <string name="prefs_keypress_sound_volume_settings">"Bonyeza kitufe cha kiwango cha sauti"</string>
     <string name="prefs_key_longpress_timeout_settings">"Ucheleweshaji wa kubofya kitufe na kushikilia"</string>

--- a/app/src/main/res/values-ta-rIN/strings.xml
+++ b/app/src/main/res/values-ta-rIN/strings.xml
@@ -38,6 +38,7 @@
     <string name="subtype_traditional">"பாரம்பரியமானது"</string>
     <string name="subtype_compact">"வசதியான"</string>
     <string name="add">"சேர்"</string>
+    <string name="remove">"அகற்று"</string>
     <string name="prefs_keypress_vibration_duration_settings">"விசையழுத்த அதிர்வின் காலஅளவு"</string>
     <string name="prefs_keypress_sound_volume_settings">"விசையழுத்த ஒலியளவு"</string>
     <string name="prefs_key_longpress_timeout_settings">"விசைக்கான நீண்ட அழுத்த நேரம்"</string>

--- a/app/src/main/res/values-te-rIN/strings.xml
+++ b/app/src/main/res/values-te-rIN/strings.xml
@@ -38,6 +38,7 @@
     <string name="subtype_traditional">"సాంప్రదాయకం"</string>
     <string name="subtype_compact">"కాంపాక్ట్"</string>
     <string name="add">"జోడించండి"</string>
+    <string name="remove">"తీసివేయి"</string>
     <string name="prefs_keypress_vibration_duration_settings">"కీని నొక్కినప్పుడు వైబ్రేషన్ వ్యవధి"</string>
     <string name="prefs_keypress_sound_volume_settings">"కీని నొక్కినప్పుడు చేసే ధ్వని వాల్యూమ్"</string>
     <string name="prefs_key_longpress_timeout_settings">"కీని ఎక్కువసేపు నొక్కి ఉంచాల్సిన సమయంలో ఆలస్యం"</string>

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -38,6 +38,7 @@
     <string name="subtype_traditional">"ดั้งเดิม"</string>
     <string name="subtype_compact">"แบบกะทัดรัด"</string>
     <string name="add">"เพิ่ม"</string>
+    <string name="remove">"ลบ"</string>
     <string name="prefs_keypress_vibration_duration_settings">"ระยะเวลาการสั่นเมื่อกดแป้นพิมพ์"</string>
     <string name="prefs_keypress_sound_volume_settings">"ระดับเสียงเมื่อกดแป้นพิมพ์"</string>
     <string name="prefs_key_longpress_timeout_settings">"การหน่วงเวลาของการกดแป้นค้าง"</string>

--- a/app/src/main/res/values-tl/strings.xml
+++ b/app/src/main/res/values-tl/strings.xml
@@ -38,6 +38,7 @@
     <string name="subtype_traditional">"Traditional"</string>
     <string name="subtype_compact">"Compact"</string>
     <string name="add">"Idagdag"</string>
+    <string name="remove">"Alisin"</string>
     <string name="prefs_keypress_vibration_duration_settings">"Tagal ng vibration ng keypress"</string>
     <string name="prefs_keypress_sound_volume_settings">"Volume ng tunog ng keypress"</string>
     <string name="prefs_key_longpress_timeout_settings">"Delay sa long press ng key"</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -38,6 +38,7 @@
     <string name="subtype_traditional">"Geleneksel"</string>
     <string name="subtype_compact">"Kompakt"</string>
     <string name="add">"Ekle"</string>
+    <string name="remove">"Kaldır"</string>
     <string name="prefs_keypress_vibration_duration_settings">"Tuşa basma titreşim süresi"</string>
     <string name="prefs_keypress_sound_volume_settings">"Tuşa basma ses seviyesi"</string>
     <string name="prefs_key_longpress_timeout_settings">"Tuşa uzun basma gecikmesi"</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -38,6 +38,7 @@
     <string name="subtype_traditional">"традиційна"</string>
     <string name="subtype_compact">"компактна"</string>
     <string name="add">"Додати"</string>
+    <string name="remove">"Видалити"</string>
     <string name="prefs_keypress_vibration_duration_settings">"Вібрація при натисканні клавіш"</string>
     <string name="prefs_keypress_sound_volume_settings">"Гучність натискання клавіш"</string>
     <string name="prefs_key_longpress_timeout_settings">"Затримка довгого натискання"</string>

--- a/app/src/main/res/values-ur-rPK/strings.xml
+++ b/app/src/main/res/values-ur-rPK/strings.xml
@@ -38,6 +38,7 @@
     <string name="subtype_traditional">"روایتی"</string>
     <string name="subtype_compact">"کمپیکٹ"</string>
     <string name="add">"شامل کریں"</string>
+    <string name="remove">"ہٹائیں"</string>
     <string name="prefs_keypress_vibration_duration_settings">"کلید دبانے پر وائبریشن کا دورانیہ"</string>
     <string name="prefs_keypress_sound_volume_settings">"کلید دبانے پر آواز کا والیوم"</string>
     <string name="prefs_key_longpress_timeout_settings">"کلید کو دیر تک دبانے کی تاخیر"</string>

--- a/app/src/main/res/values-uz-rUZ/strings.xml
+++ b/app/src/main/res/values-uz-rUZ/strings.xml
@@ -38,6 +38,7 @@
     <string name="subtype_traditional">"an’anaviy"</string>
     <string name="subtype_compact">"ixcham"</string>
     <string name="add">"Qo‘shish"</string>
+    <string name="remove">"Olib tashlash"</string>
     <string name="prefs_keypress_vibration_duration_settings">"Tugma bosilganda tebranish vaqti"</string>
     <string name="prefs_keypress_sound_volume_settings">"Tugma bosilgandagi ovoz"</string>
     <string name="prefs_key_longpress_timeout_settings">"Tugmani bosib turish"</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -39,6 +39,7 @@
     <string name="subtype_traditional">"Truyền thống"</string>
     <string name="subtype_compact">"Viết tắt"</string>
     <string name="add">"Thêm"</string>
+    <string name="remove">"Xóa"</string>
     <string name="prefs_keypress_vibration_duration_settings">"Thời gian rung khi nhấn phím"</string>
     <string name="prefs_keypress_sound_volume_settings">"Âm lượng khi nhấn phím"</string>
     <string name="prefs_key_longpress_timeout_settings">"Thời gian trễ nhấn và giữ phím"</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -39,6 +39,7 @@
     <string name="subtype_traditional">"传统"</string>
     <string name="subtype_compact">"紧凑型"</string>
     <string name="add">"添加"</string>
+    <string name="remove">"删除"</string>
     <string name="prefs_keypress_vibration_duration_settings">"按键振动时长"</string>
     <string name="prefs_keypress_sound_volume_settings">"按键音量"</string>
     <string name="prefs_key_longpress_timeout_settings">"按键长按延迟"</string>

--- a/app/src/main/res/values-zh-rHK/strings.xml
+++ b/app/src/main/res/values-zh-rHK/strings.xml
@@ -38,6 +38,7 @@
     <string name="subtype_traditional">"傳統"</string>
     <string name="subtype_compact">"精簡版"</string>
     <string name="add">"新增"</string>
+    <string name="remove">"移除"</string>
     <string name="prefs_keypress_vibration_duration_settings">"按鍵震動時間"</string>
     <string name="prefs_keypress_sound_volume_settings">"按鍵音量"</string>
     <string name="prefs_key_longpress_timeout_settings">"長按鍵延遲"</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -38,6 +38,7 @@
     <string name="subtype_traditional">"傳統"</string>
     <string name="subtype_compact">"精簡"</string>
     <string name="add">"新增"</string>
+    <string name="remove">"移除"</string>
     <string name="prefs_keypress_vibration_duration_settings">"按鍵震動持續時間"</string>
     <string name="prefs_keypress_sound_volume_settings">"按鍵音量"</string>
     <string name="prefs_key_longpress_timeout_settings">"按鍵長按延遲"</string>

--- a/app/src/main/res/values-zu/strings.xml
+++ b/app/src/main/res/values-zu/strings.xml
@@ -38,6 +38,7 @@
     <string name="subtype_traditional">"Tradition"</string>
     <string name="subtype_compact">"Okuqoqene ndawonye"</string>
     <string name="add">"Engeza"</string>
+    <string name="remove">"Khipha"</string>
     <string name="prefs_keypress_vibration_duration_settings">"Ubude besikhathi sokudlidliza ukucindezela ukhiye"</string>
     <string name="prefs_keypress_sound_volume_settings">"Ivolumu yomsindo wokucindezela ukhiye"</string>
     <string name="prefs_key_longpress_timeout_settings">"Ukulibazisa ukucindezela isikhashana ukhiye"</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -83,6 +83,8 @@
 
     <!-- Title of the button to add a language in the settings dialog [CHAR LIMIT=15] -->
     <string name="add">Add</string>
+    <!-- Title of the button to remove a language in the settings dialog [CHAR LIMIT=15] -->
+    <string name="remove">Remove</string>
 
     <!-- Title of the settings for keypress vibration duration [CHAR LIMIT=35] -->
     <string name="prefs_keypress_vibration_duration_settings">Keypress vibration duration</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -113,5 +113,4 @@
     <string name="remove_language">Remove language</string>
     <string name="generic_language_layouts"><xliff:g id="LANGUAGE_NAME" example="English (US)">%s</xliff:g> keyboard layouts</string>
     <string name="change_keyboard">Change keyboard</string>
-    <string name="layout_not_disabled">At least one keyboard layout must be enabled</string>
 </resources>


### PR DESCRIPTION
This is my proposal for how to improve adding a new language based on the discussion in #291 to be more consistent with editing an existing language. To avoid needing a confirmation button so that editing the language settings stays consistent with the other settings, I'm changing this to specifically not be a wizard. I added back the multi-select in the dialog to add a language, and now regardless of how many languages are being added, after accepting the dialog, the user will stay on the main languages settings page. Since most users probably don't use non-default layouts, not going to the individual language page is probably fine (and might actually save time from not needing to back out of the page).

Similarly, I moved the remove language button to be on the main language settings page so that the individual languages are only added and removed in one place through popups so that the individual languages' settings seem more fixed, like the other settings, so that there isn't a need for confirmation buttons in them.

I also updated the individual language settings pages to allow unchecking the all of the layouts temporarily in case the user unchecks the currently enabled subtype before enabling a different one because it could be annoying to be blocked from unchecking a layout because of the order of checking/unchecking the items. If the user leaves without enabling a different layout it will leave the last unchecked layout as enabled and show a toast. One alternative option would be to disable the preference when only one layout is enabled to make it more clear that it can't be disabled before the user even tries to uncheck it. I also disabled the layout preference for languages with only one layout.