### PR TITLE
Improve input method picker

### DIFF
--- a/app/src/main/java/rkr/simplekeyboard/inputmethod/latin/LatinIME.java
+++ b/app/src/main/java/rkr/simplekeyboard/inputmethod/latin/LatinIME.java
@@ -706,7 +706,7 @@ public class LatinIME extends InputMethodService implements KeyboardActionListen
         }
         if (mRichImm.hasMultipleEnabledSubtypes()) {
             mOptionsDialog = mRichImm.showSubtypePicker(this,
-                    mKeyboardSwitcher.getMainKeyboardView().getWindowToken());
+                    mKeyboardSwitcher.getMainKeyboardView().getWindowToken(), this);
             return true;
         }
         if (mRichImm.hasMultipleEnabledImesOrSubtypes(true /* include aux subtypes */)) {

--- a/app/src/main/java/rkr/simplekeyboard/inputmethod/latin/LatinIME.java
+++ b/app/src/main/java/rkr/simplekeyboard/inputmethod/latin/LatinIME.java
@@ -704,16 +704,9 @@ public class LatinIME extends InputMethodService implements KeyboardActionListen
         if (isShowingOptionDialog()) {
             return false;
         }
-        if (mRichImm.hasMultipleEnabledSubtypes()) {
-            mOptionsDialog = mRichImm.showSubtypePicker(this,
-                    mKeyboardSwitcher.getMainKeyboardView().getWindowToken(), this);
-            return true;
-        }
-        if (mRichImm.hasMultipleEnabledImesOrSubtypes(true /* include aux subtypes */)) {
-            mRichImm.showInputMethodPicker();
-            return true;
-        }
-        return false;
+        mOptionsDialog = mRichImm.showSubtypePicker(this,
+                mKeyboardSwitcher.getMainKeyboardView().getWindowToken(), this);
+        return mOptionsDialog != null;
     }
 
     @Override

--- a/app/src/main/java/rkr/simplekeyboard/inputmethod/latin/RichInputMethodManager.java
+++ b/app/src/main/java/rkr/simplekeyboard/inputmethod/latin/RichInputMethodManager.java
@@ -24,7 +24,11 @@ import android.inputmethodservice.InputMethodService;
 import android.os.AsyncTask;
 import android.os.Build;
 import android.os.IBinder;
+import android.text.Spannable;
+import android.text.SpannableString;
+import android.text.SpannableStringBuilder;
 import android.text.TextUtils;
+import android.text.style.RelativeSizeSpan;
 import android.view.Window;
 import android.view.WindowManager;
 import android.view.inputmethod.InputMethodInfo;
@@ -631,13 +635,22 @@ public class RichInputMethodManager {
                     && subtypeInfo.virtualSubtype.equals(currentSubtype)) {
                 currentSubtypeIndex = i;
             }
-            final String text;
+
+            final SpannableString itemTitle;
+            final SpannableString itemSubtitle;
             if (!TextUtils.isEmpty(subtypeInfo.subtypeName)) {
-                text = subtypeInfo.subtypeName + "\n";
+                itemTitle = new SpannableString(subtypeInfo.subtypeName);
+                itemSubtitle = new SpannableString("\n" + subtypeInfo.imeName);
             } else {
-                text = "";
+                itemTitle = new SpannableString(subtypeInfo.imeName);
+                itemSubtitle = new SpannableString("");
             }
-            items[i++] = text + subtypeInfo.imeName;
+            itemTitle.setSpan(new RelativeSizeSpan(0.9f), 0,itemTitle.length(),
+                    Spannable.SPAN_INCLUSIVE_INCLUSIVE);
+            itemSubtitle.setSpan(new RelativeSizeSpan(0.85f), 0,itemSubtitle.length(),
+                    Spannable.SPAN_EXCLUSIVE_INCLUSIVE);
+
+            items[i++] = new SpannableStringBuilder().append(itemTitle).append(itemSubtitle);
         }
         final DialogInterface.OnClickListener listener = new DialogInterface.OnClickListener() {
             @Override

--- a/app/src/main/java/rkr/simplekeyboard/inputmethod/latin/RichInputMethodManager.java
+++ b/app/src/main/java/rkr/simplekeyboard/inputmethod/latin/RichInputMethodManager.java
@@ -695,8 +695,10 @@ public class RichInputMethodManager {
                 }
                 final SubtypeInfo subtypeInfo = new SubtypeInfo();
                 subtypeInfo.systemSubtype = subtype;
-                subtypeInfo.subtypeName = subtype.getDisplayName(context, packageName,
-                        applicationInfo);
+                if (!subtype.overridesImplicitlyEnabledSubtype()) {
+                    subtypeInfo.subtypeName = subtype.getDisplayName(context, packageName,
+                            applicationInfo);
+                }
                 subtypeInfo.imeName = imeName;
                 subtypeInfo.imiId = imiId;
                 subtypeInfoList.add(subtypeInfo);

--- a/app/src/main/java/rkr/simplekeyboard/inputmethod/latin/RichInputMethodManager.java
+++ b/app/src/main/java/rkr/simplekeyboard/inputmethod/latin/RichInputMethodManager.java
@@ -23,7 +23,6 @@ import android.content.SharedPreferences;
 import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageManager;
 import android.inputmethodservice.InputMethodService;
-import android.os.AsyncTask;
 import android.os.Build;
 import android.os.IBinder;
 import android.text.Spannable;
@@ -45,6 +44,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.concurrent.Executors;
 
 import rkr.simplekeyboard.inputmethod.R;
 import rkr.simplekeyboard.inputmethod.compat.PreferenceManagerCompat;
@@ -61,7 +61,6 @@ import rkr.simplekeyboard.inputmethod.latin.utils.SubtypeLocaleUtils;
 // non final for easy mocking.
 public class RichInputMethodManager {
     private static final String TAG = RichInputMethodManager.class.getSimpleName();
-    private static final boolean DEBUG = false;
 
     private RichInputMethodManager() {
         // This utility class is not publicly instantiable.
@@ -661,7 +660,7 @@ public class RichInputMethodManager {
         });
         imiList.addAll(mImmService.getEnabledInputMethodList());
 
-        for (InputMethodInfo imi : imiList) {
+        for (final InputMethodInfo imi : imiList) {
             final CharSequence imeName = imi.loadLabel(packageManager);
             final String imiId = imi.getId();
             final String packageName = imi.getPackageName();
@@ -690,7 +689,7 @@ public class RichInputMethodManager {
             }
 
             final ApplicationInfo applicationInfo = imi.getServiceInfo().applicationInfo;
-            for (InputMethodSubtype subtype : subtypes) {
+            for (final InputMethodSubtype subtype : subtypes) {
                 if (subtype.isAuxiliary()) {
                     continue;
                 }
@@ -731,12 +730,11 @@ public class RichInputMethodManager {
             return;
         }
         final InputMethodManager imm = mImmService;
-        new AsyncTask<Void, Void, Void>() {
+        Executors.newSingleThreadExecutor().execute(new Runnable() {
             @Override
-            protected Void doInBackground(Void... params) {
+            public void run() {
                 imm.setInputMethodAndSubtype(token, imiId, subtype);
-                return null;
             }
-        }.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
+        });
     }
 }


### PR DESCRIPTION
This changes the custom input method / subtype picker dialog to also include other IMEs. Since it now shows all enabled IMEs, this picker will always be used when long pressing the language switch key and spacebar (rather than fall back to the system picker when only one subtype is enabled in Simple Keyboard) in order to be more consistent.

I don't fully understand why, but through testing I found that setting the `overridesImplicitlyEnabledSubtype` attribute on the one `InputMethodSubtype` that is defined for the IME causes the system subtype picker to not display the label for the subtype, even if one is defined. To be consistent with that, I'm also skipping the subtype label. This prevents the issue of Gboard showing "Multilingual typing" in the picker.