### PR TITLE
Use the German-Swiss layout for Germany too

### DIFF
--- a/app/src/main/java/rkr/simplekeyboard/inputmethod/latin/utils/SubtypeLocaleUtils.java
+++ b/app/src/main/java/rkr/simplekeyboard/inputmethod/latin/utils/SubtypeLocaleUtils.java
@@ -389,7 +389,6 @@ public final class SubtypeLocaleUtils {
                     addGenericLayouts();
                     break;
                 case LOCALE_CZECH:
-                case LOCALE_GERMAN:
                 case LOCALE_CROATIAN:
                 case LOCALE_HUNGARIAN:
                 case LOCALE_SLOVENIAN:
@@ -422,6 +421,7 @@ public final class SubtypeLocaleUtils {
                     addLayout(LAYOUT_NORDIC);
                     addGenericLayouts();
                     break;
+                case LOCALE_GERMAN:
                 case LOCALE_GERMAN_SWITZERLAND:
                 case LOCALE_FRENCH_SWITZERLAND:
                 case LOCALE_ITALIAN_SWITZERLAND:


### PR DESCRIPTION
Both layouts are very similar on a full keyboard. On phone screens there is almost no difference or no difference at all.

Partially solves #254.