### PR TITLE
Fix wrong capital sharp S (ß, U+00DF)

### DIFF
--- a/app/src/main/java/rkr/simplekeyboard/inputmethod/latin/common/StringUtils.java
+++ b/app/src/main/java/rkr/simplekeyboard/inputmethod/latin/common/StringUtils.java
@@ -244,7 +244,12 @@ public final class StringUtils {
         if (label == null) {
             return label;
         }
-        return label.toUpperCase(getLocaleUsedForToTitleCase(locale));
+        titleCaseLabel = label.toUpperCase(getLocaleUsedForToTitleCase(locale))
+        if (titleCaseLabel == "SS"){
+            // The java function String.toUpperCase() converts the sharp S (ß, U+00DF) into 'SS' instead of ẞ (U+1E9E). That's wrong.
+            titleCaseLabel = "\u+1E9E";
+        }
+        return titleCaseLabel;
     }
 
     public static int toTitleCaseOfKeyCode(final int code, final Locale locale) {


### PR DESCRIPTION
The java function String.toUpperCase() converts the sharp S (ß, U+00DF) into 'SS' instead of ẞ (U+1E9E). That's wrong, I fixed it.