### PR TITLE
Georgian keyboard: remove uppercase

### DIFF
--- a/app/src/main/res/xml/rowkeys_georgian1.xml
+++ b/app/src/main/res/xml/rowkeys_georgian1.xml
@@ -31,15 +31,18 @@
                         latin:keySpec="Q" />
                     <!-- U+10ED: "ჭ" GEORGIAN LETTER CHAR -->
                     <Key
-                        latin:keySpec="&#x10ED;" />
+                        latin:keySpec="&#x10ED;"
+                        latin:keyLabelFlags="preserveCase" />
                     <Key
                         latin:keySpec="E" />
                     <!-- U+10E6: "ღ" GEORGIAN LETTER GHAN -->
                     <Key
-                        latin:keySpec="&#x10E6;" />
+                        latin:keySpec="&#x10E6;"
+                        latin:keyLabelFlags="preserveCase" />
                     <!-- U+10D7: "თ" GEORGIAN LETTER TAN -->
                     <Key
-                        latin:keySpec="&#x10D7;" />
+                        latin:keySpec="&#x10D7;"
+                        latin:keyLabelFlags="preserveCase" />
                     <Key
                         latin:keySpec="Y" />
                     <Key
@@ -103,6 +106,7 @@
                     <!-- U+10ED: "ჭ" GEORGIAN LETTER CHAR -->
                     <Key
                         latin:keySpec="&#x10ED;"
+                        latin:keyLabelFlags="preserveCase"
                         latin:keyHintLabel="2"
                         latin:additionalMoreKeys="2" />
                     <Key
@@ -112,11 +116,13 @@
                     <!-- U+10E6: "ღ" GEORGIAN LETTER GHAN -->
                     <Key
                         latin:keySpec="&#x10E6;"
+                        latin:keyLabelFlags="preserveCase"
                         latin:keyHintLabel="4"
                         latin:additionalMoreKeys="4" />
                     <!-- U+10D7: "თ" GEORGIAN LETTER TAN -->
                     <Key
                         latin:keySpec="&#x10D7;"
+                        latin:keyLabelFlags="preserveCase"
                         latin:keyHintLabel="5"
                         latin:additionalMoreKeys="5" />
                     <Key

--- a/app/src/main/res/xml/rowkeys_georgian2.xml
+++ b/app/src/main/res/xml/rowkeys_georgian2.xml
@@ -29,7 +29,8 @@
                 latin:keySpec="A" />
             <!-- U+10E8: "შ" GEORGIAN LETTER SHIN -->
             <Key
-                latin:keySpec="&#x10E8;" />
+                latin:keySpec="&#x10E8;"
+                latin:keyLabelFlags="preserveCase" />
             <Key
                 latin:keySpec="D" />
             <Key
@@ -40,7 +41,8 @@
                 latin:keySpec="H" />
             <!-- U+10DF: "ჟ" GEORGIAN LETTER ZHAR -->
             <Key
-                latin:keySpec="&#x10DF;" />
+                latin:keySpec="&#x10DF;"
+                latin:keyLabelFlags="preserveCase" />
             <Key
                 latin:keySpec="K" />
             <Key

--- a/app/src/main/res/xml/rowkeys_georgian3.xml
+++ b/app/src/main/res/xml/rowkeys_georgian3.xml
@@ -27,12 +27,14 @@
         >
             <!-- U+10EB: "ძ" GEORGIAN LETTER JIL -->
             <Key
-                latin:keySpec="&#x10EB;" />
+                latin:keySpec="&#x10EB;"
+                latin:keyLabelFlags="preserveCase" />
             <Key
                 latin:keySpec="X" />
             <!-- U+10E9: "ჩ" GEORGIAN LETTER CHIN -->
             <Key
-                latin:keySpec="&#x10E9;" />
+                latin:keySpec="&#x10E9;"
+                latin:keyLabelFlags="preserveCase" />
             <Key
                 latin:keySpec="V" />
             <Key


### PR DESCRIPTION
Georgians do not use uppercase letters at all (although Georgian uppercase letters exist in Unicode).