### PR TITLE
Georgian layout: add missing letters to `moreKeys`

### DIFF
--- a/app/src/main/res/xml/rowkeys_georgian1.xml
+++ b/app/src/main/res/xml/rowkeys_georgian1.xml
@@ -78,20 +78,26 @@
                     <!-- U+10E5: "ქ" GEORGIAN LETTER GHAN -->
                     <Key
                         latin:keySpec="&#x10E5;" />
-                    <!-- U+10EC: "წ" GEORGIAN LETTER CIL -->
+                    <!-- U+10EC: "წ" GEORGIAN LETTER CIL
+                         U+10ED: "ჭ" GEORGIAN LETTER CHAR -->
                     <Key
-                        latin:keySpec="&#x10EC;" />
+                        latin:keySpec="&#x10EC;"
+                        latin:moreKeys="&#x10ED;" />
                     <!-- U+10D4: "ე" GEORGIAN LETTER EN
                          U+10F1: "ჱ" GEORGIAN LETTER HE -->
                     <Key
                         latin:keySpec="&#x10D4;"
                         latin:moreKeys="&#x10F1;" />
-                    <!-- U+10E0: "რ" GEORGIAN LETTER RAE -->
+                    <!-- U+10E0: "რ" GEORGIAN LETTER RAE
+                         U+10E6: "ღ" GEORGIAN LETTER GHAN -->
                     <Key
-                        latin:keySpec="&#x10E0;" />
-                    <!-- U+10E2: "ტ" GEORGIAN LETTER TAR -->
+                        latin:keySpec="&#x10E0;"
+                        latin:moreKeys="&#x10E6;" />
+                    <!-- U+10E2: "ტ" GEORGIAN LETTER TAR
+                         U+10D7: "თ" GEORGIAN LETTER TAN -->
                     <Key
-                        latin:keySpec="&#x10E2;" />
+                        latin:keySpec="&#x10E2;"
+                        latin:moreKeys="&#x10D7;" />
                     <!-- U+10E7: "ყ" GEORGIAN LETTER QAR
                          U+10F8: "ჸ" GEORGIAN LETTER ELIFI -->
                     <Key
@@ -192,9 +198,11 @@
                         latin:keySpec="&#x10E5;"
                         latin:keyHintLabel="1"
                         latin:additionalMoreKeys="1" />
-                    <!-- U+10EC: "წ" GEORGIAN LETTER CIL -->
+                    <!-- U+10EC: "წ" GEORGIAN LETTER CIL
+                         U+10ED: "ჭ" GEORGIAN LETTER CHAR -->
                     <Key
                         latin:keySpec="&#x10EC;"
+                        latin:moreKeys="&#x10ED;"
                         latin:keyHintLabel="2"
                         latin:additionalMoreKeys="2" />
                     <!-- U+10D4: "ე" GEORGIAN LETTER EN
@@ -204,14 +212,18 @@
                         latin:moreKeys="&#x10F1;"
                         latin:keyHintLabel="3"
                         latin:additionalMoreKeys="3" />
-                    <!-- U+10E0: "რ" GEORGIAN LETTER RAE -->
+                    <!-- U+10E0: "რ" GEORGIAN LETTER RAE
+                         U+10E6: "ღ" GEORGIAN LETTER GHAN -->
                     <Key
                         latin:keySpec="&#x10E0;"
+                        latin:moreKeys="&#x10E6;"
                         latin:keyHintLabel="4"
                         latin:additionalMoreKeys="4" />
-                    <!-- U+10E2: "ტ" GEORGIAN LETTER TAR -->
+                    <!-- U+10E2: "ტ" GEORGIAN LETTER TAR
+                         U+10D7: "თ" GEORGIAN LETTER TAN -->
                     <Key
                         latin:keySpec="&#x10E2;"
+                        latin:moreKeys="&#x10D7;"
                         latin:keyHintLabel="5"
                         latin:additionalMoreKeys="5" />
                     <!-- U+10E7: "ყ" GEORGIAN LETTER QAR

--- a/app/src/main/res/xml/rowkeys_georgian1.xml
+++ b/app/src/main/res/xml/rowkeys_georgian1.xml
@@ -27,14 +27,20 @@
                 <case
                     latin:keyboardLayoutSetElement="alphabetManualShifted|alphabetShiftLocked"
                 >
+                    <!-- U+10E5: "ქ" GEORGIAN LETTER GHAN -->
                     <Key
-                        latin:keySpec="Q" />
+                        latin:keySpec="&#x10E5;"
+                        latin:keyLabelFlags="preserveCase" />
                     <!-- U+10ED: "ჭ" GEORGIAN LETTER CHAR -->
                     <Key
                         latin:keySpec="&#x10ED;"
                         latin:keyLabelFlags="preserveCase" />
+                    <!-- U+10D4: "ე" GEORGIAN LETTER EN
+                         U+10F1: "ჱ" GEORGIAN LETTER HE -->
                     <Key
-                        latin:keySpec="E" />
+                        latin:keySpec="&#x10D4;"
+                        latin:moreKeys="&#x10F1;"
+                        latin:keyLabelFlags="preserveCase" />
                     <!-- U+10E6: "ღ" GEORGIAN LETTER GHAN -->
                     <Key
                         latin:keySpec="&#x10E6;"
@@ -43,16 +49,30 @@
                     <Key
                         latin:keySpec="&#x10D7;"
                         latin:keyLabelFlags="preserveCase" />
+                    <!-- U+10E7: "ყ" GEORGIAN LETTER QAR
+                         U+10F8: "ჸ" GEORGIAN LETTER ELIFI -->
                     <Key
-                        latin:keySpec="Y" />
+                        latin:keySpec="&#x10E7;"
+                        latin:moreKeys="&#x10F8;"
+                        latin:keyLabelFlags="preserveCase" />
+                    <!-- U+10E3: "უ" GEORGIAN LETTER UN -->
                     <Key
-                        latin:keySpec="U" />
+                        latin:keySpec="&#x10E3;"
+                        latin:keyLabelFlags="preserveCase" />
+                    <!-- U+10D8: "ი" GEORGIAN LETTER IN
+                         U+10F2: "ჲ" GEORGIAN LETTER HIE -->
                     <Key
-                        latin:keySpec="I" />
+                        latin:keySpec="&#x10D8;"
+                        latin:moreKeys="&#x10F2;"
+                        latin:keyLabelFlags="preserveCase" />
+                    <!-- U+10DD: "ო" GEORGIAN LETTER ON -->
                     <Key
-                        latin:keySpec="O" />
+                        latin:keySpec="&#x10DD;"
+                        latin:keyLabelFlags="preserveCase" />
+                    <!-- U+10DE: "პ" GEORGIAN LETTER PAR -->
                     <Key
-                        latin:keySpec="P" />
+                        latin:keySpec="&#x10DE;"
+                        latin:keyLabelFlags="preserveCase" />
                 </case>
                 <default>
                     <!-- U+10E5: "ქ" GEORGIAN LETTER GHAN -->
@@ -99,8 +119,10 @@
                 <case
                     latin:keyboardLayoutSetElement="alphabetManualShifted|alphabetShiftLocked"
                     >
+                    <!-- U+10E5: "ქ" GEORGIAN LETTER GHAN -->
                     <Key
-                        latin:keySpec="Q"
+                        latin:keySpec="&#x10E5;"
+                        latin:keyLabelFlags="preserveCase"
                         latin:keyHintLabel="1"
                         latin:additionalMoreKeys="1" />
                     <!-- U+10ED: "ჭ" GEORGIAN LETTER CHAR -->
@@ -109,8 +131,12 @@
                         latin:keyLabelFlags="preserveCase"
                         latin:keyHintLabel="2"
                         latin:additionalMoreKeys="2" />
+                    <!-- U+10D4: "ე" GEORGIAN LETTER EN
+                         U+10F1: "ჱ" GEORGIAN LETTER HE -->
                     <Key
-                        latin:keySpec="E"
+                        latin:keySpec="&#x10D4;"
+                        latin:moreKeys="&#x10F1;"
+                        latin:keyLabelFlags="preserveCase"
                         latin:keyHintLabel="3"
                         latin:additionalMoreKeys="3" />
                     <!-- U+10E6: "ღ" GEORGIAN LETTER GHAN -->
@@ -125,24 +151,38 @@
                         latin:keyLabelFlags="preserveCase"
                         latin:keyHintLabel="5"
                         latin:additionalMoreKeys="5" />
+                    <!-- U+10E7: "ყ" GEORGIAN LETTER QAR
+                         U+10F8: "ჸ" GEORGIAN LETTER ELIFI -->
                     <Key
-                        latin:keySpec="Y"
+                        latin:keySpec="&#x10E7;"
+                        latin:moreKeys="&#x10F8;"
+                        latin:keyLabelFlags="preserveCase"
                         latin:keyHintLabel="6"
                         latin:additionalMoreKeys="6" />
+                    <!-- U+10E3: "უ" GEORGIAN LETTER UN -->
                     <Key
-                        latin:keySpec="U"
+                        latin:keySpec="&#x10E3;"
+                        latin:keyLabelFlags="preserveCase"
                         latin:keyHintLabel="7"
                         latin:additionalMoreKeys="7" />
+                    <!-- U+10D8: "ი" GEORGIAN LETTER IN
+                         U+10F2: "ჲ" GEORGIAN LETTER HIE -->
                     <Key
-                        latin:keySpec="I"
+                        latin:keySpec="&#x10D8;"
+                        latin:moreKeys="&#x10F2;"
+                        latin:keyLabelFlags="preserveCase"
                         latin:keyHintLabel="8"
                         latin:additionalMoreKeys="8" />
+                    <!-- U+10DD: "ო" GEORGIAN LETTER ON -->
                     <Key
-                        latin:keySpec="O"
+                        latin:keySpec="&#x10DD;"
+                        latin:keyLabelFlags="preserveCase"
                         latin:keyHintLabel="9"
                         latin:additionalMoreKeys="9" />
+                    <!-- U+10DE: "პ" GEORGIAN LETTER PAR -->
                     <Key
-                        latin:keySpec="P"
+                        latin:keySpec="&#x10DE;"
+                        latin:keyLabelFlags="preserveCase"
                         latin:keyHintLabel="0"
                         latin:additionalMoreKeys="0" />
                 </case>

--- a/app/src/main/res/xml/rowkeys_georgian2.xml
+++ b/app/src/main/res/xml/rowkeys_georgian2.xml
@@ -25,28 +25,50 @@
         <case
             latin:keyboardLayoutSetElement="alphabetManualShifted|alphabetShiftLocked"
         >
+            <!-- U+10D0: "ა" GEORGIAN LETTER AN
+                 U+10FA: "ჺ" GEORGIAN LETTER AIN -->
             <Key
-                latin:keySpec="A" />
+                latin:keySpec="&#x10D0;"
+                latin:moreKeys="&#x10FA;"
+                latin:keyLabelFlags="preserveCase" />
             <!-- U+10E8: "შ" GEORGIAN LETTER SHIN -->
             <Key
                 latin:keySpec="&#x10E8;"
                 latin:keyLabelFlags="preserveCase" />
+            <!-- U+10D3: "დ" GEORGIAN LETTER DON -->
             <Key
-                latin:keySpec="D" />
+                latin:keySpec="&#x10D3;"
+                latin:keyLabelFlags="preserveCase" />
+            <!-- U+10E4: "ფ" GEORGIAN LETTER PHAR
+                 U+10F6: "ჶ" GEORGIAN LETTER FI -->
             <Key
-                latin:keySpec="F" />
+                latin:keySpec="&#x10E4;"
+                latin:moreKeys="&#x10F6;"
+                latin:keyLabelFlags="preserveCase" />
+            <!-- U+10D2: "გ" GEORGIAN LETTER GAN
+                 U+10F9: "ჹ" GEORGIAN LETTER TURNED GAN -->
             <Key
-                latin:keySpec="G" />
+                latin:keySpec="&#x10D2;"
+                latin:moreKeys="&#x10F9;"
+                latin:keyLabelFlags="preserveCase" />
+            <!-- U+10F0: "ჰ" GEORGIAN LETTER HAE
+                 U+10F5: "ჵ" GEORGIAN LETTER HOE -->
             <Key
-                latin:keySpec="H" />
+                latin:keySpec="&#x10F0;"
+                latin:moreKeys="&#x10F5;"
+                latin:keyLabelFlags="preserveCase" />
             <!-- U+10DF: "ჟ" GEORGIAN LETTER ZHAR -->
             <Key
                 latin:keySpec="&#x10DF;"
                 latin:keyLabelFlags="preserveCase" />
+            <!-- U+10D9: "კ" GEORGIAN LETTER KAN -->
             <Key
-                latin:keySpec="K" />
+                latin:keySpec="&#x10D9;"
+                latin:keyLabelFlags="preserveCase" />
+            <!-- U+10DA: "ლ" GEORGIAN LETTER LAS -->
             <Key
-                latin:keySpec="L" />
+                latin:keySpec="&#x10DA;"
+                latin:keyLabelFlags="preserveCase" />
         </case>
         <default>
             <!-- U+10D0: "ა" GEORGIAN LETTER AN

--- a/app/src/main/res/xml/rowkeys_georgian2.xml
+++ b/app/src/main/res/xml/rowkeys_georgian2.xml
@@ -76,9 +76,11 @@
             <Key
                 latin:keySpec="&#x10D0;"
                 latin:moreKeys="&#x10FA;" />
-            <!-- U+10E1: "ს" GEORGIAN LETTER SAN -->
+            <!-- U+10E1: "ს" GEORGIAN LETTER SAN
+                 U+10E8: "შ" GEORGIAN LETTER SHIN -->
             <Key
-                latin:keySpec="&#x10E1;" />
+                latin:keySpec="&#x10E1;"
+                latin:moreKeys="&#x10E8;" />
             <!-- U+10D3: "დ" GEORGIAN LETTER DON -->
             <Key
                 latin:keySpec="&#x10D3;" />
@@ -98,10 +100,11 @@
                 latin:keySpec="&#x10F0;"
                 latin:moreKeys="&#x10F5;" />
             <!-- U+10EF: "ჯ" GEORGIAN LETTER JHAN
+                 U+10DF: "ჟ" GEORGIAN LETTER ZHAR
                  U+10F7: "ჷ" GEORGIAN LETTER YN -->
             <Key
                 latin:keySpec="&#x10EF;"
-                latin:moreKeys="&#x10F7;" />
+                latin:moreKeys="&#x10DF;,&#x10F7;" />
             <!-- U+10D9: "კ" GEORGIAN LETTER KAN -->
             <Key
                 latin:keySpec="&#x10D9;" />

--- a/app/src/main/res/xml/rowkeys_georgian3.xml
+++ b/app/src/main/res/xml/rowkeys_georgian3.xml
@@ -61,17 +61,21 @@
                 latin:keyLabelFlags="preserveCase" />
         </case>
         <default>
-            <!-- U+10D6: "ზ" GEORGIAN LETTER ZEN -->
+            <!-- U+10D6: "ზ" GEORGIAN LETTER ZEN
+                 U+10EB: "ძ" GEORGIAN LETTER JIL -->
             <Key
-                latin:keySpec="&#x10D6;" />
+                latin:keySpec="&#x10D6;"
+                latin:moreKeys="&#x10EB;" />
             <!-- U+10EE: "ხ" GEORGIAN LETTER XAN
                  U+10F4: "ჴ" GEORGIAN LETTER HAR -->
             <Key
                 latin:keySpec="&#x10EE;"
                 latin:moreKeys="&#x10F4;" />
-            <!-- U+10EA: "ც" GEORGIAN LETTER CAN -->
+            <!-- U+10EA: "ც" GEORGIAN LETTER CAN
+                 U+10E9: "ჩ" GEORGIAN LETTER CHIN -->
             <Key
-                latin:keySpec="&#x10EA;" />
+                latin:keySpec="&#x10EA;"
+                latin:moreKeys="&#x10E9;" />
             <!-- U+10D5: "ვ" GEORGIAN LETTER VIN
                  U+10F3: "ჳ" GEORGIAN LETTER WE -->
             <Key

--- a/app/src/main/res/xml/rowkeys_georgian3.xml
+++ b/app/src/main/res/xml/rowkeys_georgian3.xml
@@ -23,26 +23,42 @@
 >
     <switch>
         <case
-            latin:keyboardLayoutSetElement="alphabetManualShifted"
+            latin:keyboardLayoutSetElement="alphabetManualShifted|alphabetShiftLocked"
         >
             <!-- U+10EB: "ძ" GEORGIAN LETTER JIL -->
             <Key
                 latin:keySpec="&#x10EB;"
                 latin:keyLabelFlags="preserveCase" />
+            <!-- U+10EE: "ხ" GEORGIAN LETTER XAN
+                 U+10F4: "ჴ" GEORGIAN LETTER HAR -->
             <Key
-                latin:keySpec="X" />
+                latin:keySpec="&#x10EE;"
+                latin:moreKeys="&#x10F4;"
+                latin:keyLabelFlags="preserveCase" />
             <!-- U+10E9: "ჩ" GEORGIAN LETTER CHIN -->
             <Key
                 latin:keySpec="&#x10E9;"
                 latin:keyLabelFlags="preserveCase" />
+            <!-- U+10D5: "ვ" GEORGIAN LETTER VIN
+                 U+10F3: "ჳ" GEORGIAN LETTER WE -->
             <Key
-                latin:keySpec="V" />
+                latin:keySpec="&#x10D5;"
+                latin:moreKeys="&#x10F3;"
+                latin:keyLabelFlags="preserveCase" />
+            <!-- U+10D1: "ბ" GEORGIAN LETTER BAN -->
             <Key
-                latin:keySpec="B" />
+                latin:keySpec="&#x10D1;"
+                latin:keyLabelFlags="preserveCase" />
+            <!-- U+10DC: "ნ" GEORGIAN LETTER NAR
+                 U+10FC: "ჼ" MODIFIER LETTER GEORGIAN NAR -->
             <Key
-                latin:keySpec="N" />
+                latin:keySpec="&#x10DC;"
+                latin:moreKeys="&#x10FC;"
+                latin:keyLabelFlags="preserveCase" />
+            <!-- U+10DB: "მ" GEORGIAN LETTER MAN -->
             <Key
-                latin:keySpec="M" />
+                latin:keySpec="&#x10DB;"
+                latin:keyLabelFlags="preserveCase" />
         </case>
         <default>
             <!-- U+10D6: "ზ" GEORGIAN LETTER ZEN -->


### PR DESCRIPTION
In GBoard v12:

<img src="https://user-images.githubusercontent.com/100644/211375909-964565e1-2b00-4a3b-9a20-10ac77530c95.png" width="200">

**WAS** in Simple Keyboard:

<img src="https://user-images.githubusercontent.com/100644/211375917-dec61f04-6162-4f39-a1d6-67eb816c0626.png" width="200">

**FIXED** in this pull request:

<img src="https://user-images.githubusercontent.com/100644/211375915-c44d0d03-f719-440d-97d4-b9589fae6390.png" width="200">