### PR TITLE
Latvian: set higher priority to frequent moreKeys

### DIFF
--- a/app/src/main/java/rkr/simplekeyboard/inputmethod/keyboard/internal/KeyboardTextsTable.java
+++ b/app/src/main/java/rkr/simplekeyboard/inputmethod/keyboard/internal/KeyboardTextsTable.java
@@ -2501,6 +2501,7 @@ public final class KeyboardTextsTable {
     /* Locale lv: Latvian */
     private static final String[] TEXTS_lv = {
         // U+0101: "ā" LATIN SMALL LETTER A WITH MACRON
+        // ADDITIONAL_MORE_KEY_MARKER
         // U+00E0: "à" LATIN SMALL LETTER A WITH GRAVE
         // U+00E1: "á" LATIN SMALL LETTER A WITH ACUTE
         // U+00E2: "â" LATIN SMALL LETTER A WITH CIRCUMFLEX
@@ -2509,7 +2510,7 @@ public final class KeyboardTextsTable {
         // U+00E5: "å" LATIN SMALL LETTER A WITH RING ABOVE
         // U+00E6: "æ" LATIN SMALL LETTER AE
         // U+0105: "ą" LATIN SMALL LETTER A WITH OGONEK
-        /* morekeys_a */ "\u0101,\u00E0,\u00E1,\u00E2,\u00E3,\u00E4,\u00E5,\u00E6,\u0105",
+        /* morekeys_a */ "\u0101,%,\u00E0,\u00E1,\u00E2,\u00E3,\u00E4,\u00E5,\u00E6,\u0105",
         // U+00F2: "ò" LATIN SMALL LETTER O WITH GRAVE
         // U+00F3: "ó" LATIN SMALL LETTER O WITH ACUTE
         // U+00F4: "ô" LATIN SMALL LETTER O WITH CIRCUMFLEX
@@ -2520,6 +2521,7 @@ public final class KeyboardTextsTable {
         // U+00F8: "ø" LATIN SMALL LETTER O WITH STROKE
         /* morekeys_o */ "\u00F2,\u00F3,\u00F4,\u00F5,\u00F6,\u0153,\u0151,\u00F8",
         // U+0113: "ē" LATIN SMALL LETTER E WITH MACRON
+        // ADDITIONAL_MORE_KEY_MARKER
         // U+0117: "ė" LATIN SMALL LETTER E WITH DOT ABOVE
         // U+00E8: "è" LATIN SMALL LETTER E WITH GRAVE
         // U+00E9: "é" LATIN SMALL LETTER E WITH ACUTE
@@ -2527,8 +2529,9 @@ public final class KeyboardTextsTable {
         // U+00EB: "ë" LATIN SMALL LETTER E WITH DIAERESIS
         // U+0119: "ę" LATIN SMALL LETTER E WITH OGONEK
         // U+011B: "ě" LATIN SMALL LETTER E WITH CARON
-        /* morekeys_e */ "\u0113,\u0117,\u00E8,\u00E9,\u00EA,\u00EB,\u0119,\u011B",
+        /* morekeys_e */ "\u0113,%,\u0117,\u00E8,\u00E9,\u00EA,\u00EB,\u0119,\u011B",
         // U+016B: "ū" LATIN SMALL LETTER U WITH MACRON
+        // ADDITIONAL_MORE_KEY_MARKER
         // U+0173: "ų" LATIN SMALL LETTER U WITH OGONEK
         // U+00F9: "ù" LATIN SMALL LETTER U WITH GRAVE
         // U+00FA: "ú" LATIN SMALL LETTER U WITH ACUTE
@@ -2536,60 +2539,69 @@ public final class KeyboardTextsTable {
         // U+00FC: "ü" LATIN SMALL LETTER U WITH DIAERESIS
         // U+016F: "ů" LATIN SMALL LETTER U WITH RING ABOVE
         // U+0171: "ű" LATIN SMALL LETTER U WITH DOUBLE ACUTE
-        /* morekeys_u */ "\u016B,\u0173,\u00F9,\u00FA,\u00FB,\u00FC,\u016F,\u0171",
+        /* morekeys_u */ "\u016B,%,\u0173,\u00F9,\u00FA,\u00FB,\u00FC,\u016F,\u0171",
         /* keylabel_to_alpha */ null,
         // U+012B: "ī" LATIN SMALL LETTER I WITH MACRON
+        // ADDITIONAL_MORE_KEY_MARKER
         // U+012F: "į" LATIN SMALL LETTER I WITH OGONEK
         // U+00EC: "ì" LATIN SMALL LETTER I WITH GRAVE
         // U+00ED: "í" LATIN SMALL LETTER I WITH ACUTE
         // U+00EE: "î" LATIN SMALL LETTER I WITH CIRCUMFLEX
         // U+00EF: "ï" LATIN SMALL LETTER I WITH DIAERESIS
         // U+0131: "ı" LATIN SMALL LETTER DOTLESS I
-        /* morekeys_i */ "\u012B,\u012F,\u00EC,\u00ED,\u00EE,\u00EF,\u0131",
+        /* morekeys_i */ "\u012B,%,\u012F,\u00EC,\u00ED,\u00EE,\u00EF,\u0131",
         // U+0146: "ņ" LATIN SMALL LETTER N WITH CEDILLA
+        // ADDITIONAL_MORE_KEY_MARKER
         // U+00F1: "ñ" LATIN SMALL LETTER N WITH TILDE
         // U+0144: "ń" LATIN SMALL LETTER N WITH ACUTE
-        /* morekeys_n */ "\u0146,\u00F1,\u0144",
+        /* morekeys_n */ "\u0146,%,\u00F1,\u0144",
         // U+010D: "č" LATIN SMALL LETTER C WITH CARON
+        // ADDITIONAL_MORE_KEY_MARKER
         // U+00E7: "ç" LATIN SMALL LETTER C WITH CEDILLA
         // U+0107: "ć" LATIN SMALL LETTER C WITH ACUTE
-        /* morekeys_c */ "\u010D,\u00E7,\u0107",
+        /* morekeys_c */ "\u010D,%,\u00E7,\u0107",
         /* double_quotes */ "!text/double_9qm_lqm",
         // U+0161: "š" LATIN SMALL LETTER S WITH CARON
+        // ADDITIONAL_MORE_KEY_MARKER
         // U+00DF: "ß" LATIN SMALL LETTER SHARP S
         // U+015B: "ś" LATIN SMALL LETTER S WITH ACUTE
         // U+015F: "ş" LATIN SMALL LETTER S WITH CEDILLA
-        /* morekeys_s */ "\u0161,\u00DF,\u015B,\u015F",
+        /* morekeys_s */ "\u0161,%,\u00DF,\u015B,\u015F",
         /* single_quotes */ "!text/single_9qm_lqm",
         /* keyspec_currency */ null,
         // U+00FD: "ý" LATIN SMALL LETTER Y WITH ACUTE
         // U+00FF: "ÿ" LATIN SMALL LETTER Y WITH DIAERESIS
         /* morekeys_y */ "\u00FD,\u00FF",
         // U+017E: "ž" LATIN SMALL LETTER Z WITH CARON
+        // ADDITIONAL_MORE_KEY_MARKER
         // U+017C: "ż" LATIN SMALL LETTER Z WITH DOT ABOVE
         // U+017A: "ź" LATIN SMALL LETTER Z WITH ACUTE
-        /* morekeys_z */ "\u017E,\u017C,\u017A",
+        /* morekeys_z */ "\u017E,%,\u017C,\u017A",
         // U+010F: "ď" LATIN SMALL LETTER D WITH CARON
         /* morekeys_d */ "\u010F",
         // U+0163: "ţ" LATIN SMALL LETTER T WITH CEDILLA
         // U+0165: "ť" LATIN SMALL LETTER T WITH CARON
         /* morekeys_t */ "\u0163,\u0165",
         // U+013C: "ļ" LATIN SMALL LETTER L WITH CEDILLA
+        // ADDITIONAL_MORE_KEY_MARKER
         // U+0142: "ł" LATIN SMALL LETTER L WITH STROKE
         // U+013A: "ĺ" LATIN SMALL LETTER L WITH ACUTE
         // U+013E: "ľ" LATIN SMALL LETTER L WITH CARON
-        /* morekeys_l */ "\u013C,\u0142,\u013A,\u013E",
+        /* morekeys_l */ "\u013C,%,\u0142,\u013A,\u013E",
         // U+0123: "ģ" LATIN SMALL LETTER G WITH CEDILLA
+        // ADDITIONAL_MORE_KEY_MARKER
         // U+011F: "ğ" LATIN SMALL LETTER G WITH BREVE
-        /* morekeys_g */ "\u0123,\u011F",
+        /* morekeys_g */ "\u0123,%,\u011F",
         /* single_angle_quotes */ null,
         /* double_angle_quotes */ null,
         // U+0157: "ŗ" LATIN SMALL LETTER R WITH CEDILLA
+        // ADDITIONAL_MORE_KEY_MARKER
         // U+0159: "ř" LATIN SMALL LETTER R WITH CARON
         // U+0155: "ŕ" LATIN SMALL LETTER R WITH ACUTE
-        /* morekeys_r */ "\u0157,\u0159,\u0155",
+        /* morekeys_r */ "\u0157,%,\u0159,\u0155",
         // U+0137: "ķ" LATIN SMALL LETTER K WITH CEDILLA
-        /* morekeys_k */ "\u0137",
+        // ADDITIONAL_MORE_KEY_MARKER
+        /* morekeys_k */ "\u0137,%",
     };
 
     /* Locale mk: Macedonian */


### PR DESCRIPTION
In Latvian layout in GBoard app Latvian letters with diacritics have higher priority than `latin:additionalMoreKeys`. (Similarly to French, German, Swedish languages etc.) This speeds up typing in these languages.


See the screenshots:



<img width="300" src="https://github.com/rkkr/simple-keyboard/assets/100644/1a461acb-57d1-43ac-a2d0-4ca1dc96f462" />
<img width="300" src="https://github.com/rkkr/simple-keyboard/assets/100644/66e02c8a-3b5e-44aa-8d76-024198d011a6" />
<img width="300" src="https://github.com/rkkr/simple-keyboard/assets/100644/05b5f103-afe6-4c9a-9d24-62e0b6e5bd97" /> 
