### PR TITLE
Add a setting to add an offset to the bottom of the keyboard

### DIFF
--- a/app/src/main/java/rkr/simplekeyboard/inputmethod/keyboard/KeyboardId.java
+++ b/app/src/main/java/rkr/simplekeyboard/inputmethod/keyboard/KeyboardId.java
@@ -55,6 +55,7 @@ public final class KeyboardId {
     public final int mThemeId;
     public final int mWidth;
     public final int mHeight;
+    public final int mBottomOffset;
     public final int mMode;
     public final int mElementId;
     public final EditorInfo mEditorInfo;
@@ -70,6 +71,7 @@ public final class KeyboardId {
         mThemeId = params.mKeyboardThemeId;
         mWidth = params.mKeyboardWidth;
         mHeight = params.mKeyboardHeight;
+        mBottomOffset = params.mKeyboardBottomOffset;
         mMode = params.mMode;
         mElementId = elementId;
         mEditorInfo = params.mEditorInfo;
@@ -88,6 +90,7 @@ public final class KeyboardId {
                 id.mMode,
                 id.mWidth,
                 id.mHeight,
+                id.mBottomOffset,
                 id.passwordInput(),
                 id.mLanguageSwitchKeyEnabled,
                 id.isMultiLine(),
@@ -107,6 +110,7 @@ public final class KeyboardId {
                 && other.mMode == mMode
                 && other.mWidth == mWidth
                 && other.mHeight == mHeight
+                && other.mBottomOffset == mBottomOffset
                 && other.passwordInput() == passwordInput()
                 && other.mLanguageSwitchKeyEnabled == mLanguageSwitchKeyEnabled
                 && other.isMultiLine() == isMultiLine()
@@ -166,11 +170,11 @@ public final class KeyboardId {
 
     @Override
     public String toString() {
-        return String.format(Locale.ROOT, "[%s %s:%s %dx%d %s %s%s%s%s%s%s %s]",
+        return String.format(Locale.ROOT, "[%s %s:%s %dx%d +%d %s %s%s%s%s%s%s %s]",
                 elementIdToName(mElementId),
                 mSubtype.getLocale(),
                 mSubtype.getKeyboardLayoutSet(),
-                mWidth, mHeight,
+                mWidth, mHeight, mBottomOffset,
                 modeName(mMode),
                 actionName(imeAction()),
                 (navigateNext() ? " navigateNext" : ""),

--- a/app/src/main/java/rkr/simplekeyboard/inputmethod/keyboard/KeyboardLayoutSet.java
+++ b/app/src/main/java/rkr/simplekeyboard/inputmethod/keyboard/KeyboardLayoutSet.java
@@ -98,6 +98,7 @@ public final class KeyboardLayoutSet {
         int mKeyboardThemeId;
         int mKeyboardWidth;
         int mKeyboardHeight;
+        int mKeyboardBottomOffset;
         boolean mShowMoreKeys;
         boolean mShowNumberRow;
         // Sparse array of KeyboardLayoutSet element parameters indexed by element's id.
@@ -219,9 +220,11 @@ public final class KeyboardLayoutSet {
             return this;
         }
 
-        public Builder setKeyboardGeometry(final int keyboardWidth, final int keyboardHeight) {
+        public Builder setKeyboardGeometry(final int keyboardWidth, final int keyboardHeight,
+                                           final int keyboardBottomOffset) {
             mParams.mKeyboardWidth = keyboardWidth;
             mParams.mKeyboardHeight = keyboardHeight;
+            mParams.mKeyboardBottomOffset = keyboardBottomOffset;
             return this;
         }
 

--- a/app/src/main/java/rkr/simplekeyboard/inputmethod/keyboard/KeyboardSwitcher.java
+++ b/app/src/main/java/rkr/simplekeyboard/inputmethod/keyboard/KeyboardSwitcher.java
@@ -116,8 +116,9 @@ public final class KeyboardSwitcher implements KeyboardState.SwitchActions {
         final Resources res = mThemeContext.getResources();
         final int keyboardWidth = mLatinIME.getMaxWidth();
         final int keyboardHeight = ResourceUtils.getKeyboardHeight(res, settingsValues);
+        final int keyboardBottomOffset = ResourceUtils.getKeyboardBottomOffset(res, settingsValues);
         builder.setKeyboardTheme(mKeyboardTheme.mThemeId);
-        builder.setKeyboardGeometry(keyboardWidth, keyboardHeight);
+        builder.setKeyboardGeometry(keyboardWidth, keyboardHeight, keyboardBottomOffset);
         builder.setSubtype(mRichImm.getCurrentSubtype());
         builder.setLanguageSwitchKeyEnabled(mLatinIME.shouldShowLanguageSwitchKey());
         builder.setShowSpecialChars(!settingsValues.mHideSpecialChars);

--- a/app/src/main/java/rkr/simplekeyboard/inputmethod/keyboard/internal/KeyboardBuilder.java
+++ b/app/src/main/java/rkr/simplekeyboard/inputmethod/keyboard/internal/KeyboardBuilder.java
@@ -245,11 +245,12 @@ public class KeyboardBuilder<KP extends KeyboardParams> {
             final KeyboardParams params = mParams;
             final int height = params.mId.mHeight;
             final int width = params.mId.mWidth;
+            final int bottomOffset = params.mId.mBottomOffset;
             // The bonus height isn't used to determine the other dimensions (gap/padding) to allow
             // those to stay consistent between layouts with and without the bonus height added.
             final int bonusHeight = (int)keyboardAttr.getFraction(R.styleable.Keyboard_bonusHeight,
                     height, height, 0);
-            params.mOccupiedHeight = height + bonusHeight;
+            params.mOccupiedHeight = height + bonusHeight + bottomOffset;
             params.mOccupiedWidth = width;
             params.mTopPadding = ResourceUtils.getDimensionOrFraction(keyboardAttr,
                     R.styleable.Keyboard_keyboardTopPadding, height, 0);
@@ -274,7 +275,7 @@ public class KeyboardBuilder<KP extends KeyboardParams> {
             params.mVerticalGap = keyboardAttr.getFraction(
                     R.styleable.Keyboard_verticalGap, height, height, 0);
             final float baseHeight = params.mOccupiedHeight - params.mTopPadding
-                    - params.mBottomPadding + params.mVerticalGap;
+                    - params.mBottomPadding + params.mVerticalGap - bottomOffset;
             params.mBaseHeight = baseHeight;
             params.mDefaultRowHeight = ResourceUtils.getDimensionOrFraction(keyboardAttr,
                     R.styleable.Keyboard_rowHeight, baseHeight, baseHeight / DEFAULT_KEYBOARD_ROWS);

--- a/app/src/main/java/rkr/simplekeyboard/inputmethod/latin/settings/AppearanceSettingsFragment.java
+++ b/app/src/main/java/rkr/simplekeyboard/inputmethod/latin/settings/AppearanceSettingsFragment.java
@@ -39,6 +39,7 @@ public final class AppearanceSettingsFragment extends SubScreenFragment {
         }
 
         setupKeyboardHeightSettings();
+        setupBottomOffsetPortraitSettings();
         setupKeyboardColorSettings();
     }
 
@@ -108,6 +109,48 @@ public final class AppearanceSettingsFragment extends SubScreenFragment {
                     return res.getString(R.string.settings_system_default);
                 }
                 return res.getString(R.string.abbreviation_unit_percent, value);
+            }
+
+            @Override
+            public void feedbackValue(final int value) {}
+        });
+    }
+
+    private void setupBottomOffsetPortraitSettings() {
+        final SeekBarDialogPreference pref = (SeekBarDialogPreference)findPreference(
+                Settings.PREF_BOTTOM_OFFSET_PORTRAIT);
+        if (pref == null) {
+            return;
+        }
+        final SharedPreferences prefs = getSharedPreferences();
+        final Resources res = getResources();
+        pref.setInterface(new SeekBarDialogPreference.ValueProxy() {
+            @Override
+            public void writeValue(final int value, final String key) {
+                prefs.edit().putInt(key, value).apply();
+            }
+
+            @Override
+            public void writeDefaultValue(final String key) {
+                prefs.edit().remove(key).apply();
+            }
+
+            @Override
+            public int readValue(final String key) {
+                return Settings.readBottomOffsetPortrait(prefs);
+            }
+
+            @Override
+            public int readDefaultValue(final String key) {
+                return Settings.DEFAULT_BOTTOM_OFFSET;
+            }
+
+            @Override
+            public String getValueText(final int value) {
+                if (value < 0) {
+                    return res.getString(R.string.settings_system_default);
+                }
+                return res.getString(R.string.abbreviation_unit_dp, value);
             }
 
             @Override

--- a/app/src/main/java/rkr/simplekeyboard/inputmethod/latin/settings/Settings.java
+++ b/app/src/main/java/rkr/simplekeyboard/inputmethod/latin/settings/Settings.java
@@ -48,6 +48,7 @@ public final class Settings implements SharedPreferences.OnSharedPreferenceChang
     public static final String PREF_KEYPRESS_SOUND_VOLUME = "pref_keypress_sound_volume";
     public static final String PREF_KEY_LONGPRESS_TIMEOUT = "pref_key_longpress_timeout";
     public static final String PREF_KEYBOARD_HEIGHT = "pref_keyboard_height";
+    public static final String PREF_BOTTOM_OFFSET_PORTRAIT = "pref_bottom_offset_portrait";
     public static final String PREF_KEYBOARD_COLOR = "pref_keyboard_color";
     public static final String PREF_HIDE_SPECIAL_CHARS = "pref_hide_special_chars";
     public static final String PREF_SHOW_NUMBER_ROW = "pref_show_number_row";
@@ -216,6 +217,12 @@ public final class Settings implements SharedPreferences.OnSharedPreferenceChang
             final float defaultValue) {
         return prefs.getFloat(PREF_KEYBOARD_HEIGHT, defaultValue);
     }
+
+    public static int readBottomOffsetPortrait(final SharedPreferences prefs) {
+        return prefs.getInt(PREF_BOTTOM_OFFSET_PORTRAIT, DEFAULT_BOTTOM_OFFSET);
+    }
+
+    public static final int DEFAULT_BOTTOM_OFFSET = 0;
 
     public static int readKeyboardDefaultColor(final Context context) {
         final int[] keyboardThemeColors = context.getResources().getIntArray(R.array.keyboard_theme_colors);

--- a/app/src/main/java/rkr/simplekeyboard/inputmethod/latin/settings/SettingsValues.java
+++ b/app/src/main/java/rkr/simplekeyboard/inputmethod/latin/settings/SettingsValues.java
@@ -58,6 +58,8 @@ public class SettingsValues {
     // Debug settings
     public final float mKeyboardHeightScale;
 
+    public final int mBottomOffsetPortrait;
+
     public SettingsValues(final SharedPreferences prefs, final Resources res,
             final InputAttributes inputAttributes) {
         // Get the resources
@@ -81,6 +83,7 @@ public class SettingsValues {
         mKeypressSoundVolume = Settings.readKeypressSoundVolume(prefs, res);
         mKeyPreviewPopupDismissDelay = res.getInteger(R.integer.config_key_preview_linger_timeout);
         mKeyboardHeightScale = Settings.readKeyboardHeight(prefs, DEFAULT_SIZE_SCALE);
+        mBottomOffsetPortrait = Settings.readBottomOffsetPortrait(prefs);
         mDisplayOrientation = res.getConfiguration().orientation;
         mHideSpecialChars = Settings.readHideSpecialChars(prefs);
         mShowNumberRow = Settings.readShowNumberRow(prefs);

--- a/app/src/main/java/rkr/simplekeyboard/inputmethod/latin/utils/ResourceUtils.java
+++ b/app/src/main/java/rkr/simplekeyboard/inputmethod/latin/utils/ResourceUtils.java
@@ -16,6 +16,7 @@
 
 package rkr.simplekeyboard.inputmethod.latin.utils;
 
+import android.content.res.Configuration;
 import android.content.res.Resources;
 import android.content.res.TypedArray;
 import android.graphics.Color;
@@ -202,6 +203,13 @@ public final class ResourceUtils {
         // Keyboard height will not exceed maxKeyboardHeight and will not be less than
         // minKeyboardHeight.
         return (int)Math.max(Math.min(keyboardHeight, maxKeyboardHeight), minKeyboardHeight);
+    }
+
+    public static int getKeyboardBottomOffset(final Resources res,
+                                              final SettingsValues settingsValues) {
+        return res.getConfiguration().orientation == Configuration.ORIENTATION_PORTRAIT
+                ? (int)(settingsValues.mBottomOffsetPortrait * res.getDisplayMetrics().density)
+                : 0;
     }
 
     public static boolean isValidFraction(final float fraction) {

--- a/app/src/main/res/values/config-common.xml
+++ b/app/src/main/res/values/config-common.xml
@@ -65,4 +65,9 @@
     <integer name="config_max_keyboar_height">150</integer>
     <integer name="config_min_keyboar_height">50</integer>
     <integer name="config_keyboar_height_step">5</integer>
+
+    <!-- Bottom offset -->
+    <integer name="config_max_bottom_offset_portrait">100</integer>
+    <integer name="config_min_bottom_offset_portrait">0</integer>
+    <integer name="config_bottom_offset_step">1</integer>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -101,8 +101,10 @@
     <string name="button_default">Default</string>
 
     <string translatable="false" name="abbreviation_unit_percent"><xliff:g id="PERCENTS">%s</xliff:g>%%</string>
+    <string translatable="false" name="abbreviation_unit_dp"><xliff:g id="DENSITY_INDEPENDENT_PIXELS">%d</xliff:g> dp</string>
 
     <string name="prefs_keyboard_height_settings">Keyboard height</string>
+    <string name="prefs_bottom_offset_portrait_settings">Bottom offset (portrait only)</string>
     <string name="keyboard_color">Set custom keyboard color</string>
     <string name="hide_special_chars">Hide special characters</string>
     <string name="hide_language_switch_key">Hide language switch key</string>

--- a/app/src/main/res/xml/prefs_screen_appearance.xml
+++ b/app/src/main/res/xml/prefs_screen_appearance.xml
@@ -36,4 +36,10 @@
         latin:minValue="@integer/config_min_keyboar_height"
         latin:maxValue="@integer/config_max_keyboar_height"
         latin:stepValue="@integer/config_keyboar_height_step" />
+    <rkr.simplekeyboard.inputmethod.latin.settings.SeekBarDialogPreference
+        android:key="pref_bottom_offset_portrait"
+        android:title="@string/prefs_bottom_offset_portrait_settings"
+        latin:minValue="@integer/config_min_bottom_offset_portrait"
+        latin:maxValue="@integer/config_max_bottom_offset_portrait"
+        latin:stepValue="@integer/config_bottom_offset_step" />
 </PreferenceScreen>


### PR DESCRIPTION
This adds the option to have extra padding at the bottom of the keyboard. This resolves #346.

I intentionally made this extra padding not clickable because the whole point is to shift the position of the keyboard, so I don't see a point in being able to click in this space, and depending on how large the offset is, registering clicks there seems like it would be unexpected for most users. We've had some debate on non-clickable spaces in the past, so if you disagree, I suppose I can change it.

I also only added support for portrait mode because I don't think there would be much point in landscape. In portrait mode, this offset can push the keyboard away from the navigation bar to avoid misclicks. Also, with phones having significantly smaller bezels than years ago, this can shift the keyboard back to a higher position that could be more comfortable, and due to the reduced bezels, there is extra vertical space to justify that. Landscape mode has much less available space, and doesn't have the same issue with the navigation bar being there, so I'm not sure why an offset would be beneficial there, but if you think there could be any value or want it simply for consistency, I could add it.