### PR TITLE
Fixed a typo: "LatinIME" instead of "LatineIME"

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,4 +37,4 @@ Feature it doesn't have and probably will never have:
 
 Licensed under Apache License Version 2
 
-This keyboard is based on AOSP LatineIME keyboard. You can get the original source code in https://android.googlesource.com/platform/packages/inputmethods/LatinIME/
+This keyboard is based on AOSP LatinIME keyboard. You can get the original source code in https://android.googlesource.com/platform/packages/inputmethods/LatinIME/


### PR DESCRIPTION
self-explanatory