### PR TITLE
Add subtype locale

### DIFF
--- a/app/src/main/res/xml/method.xml
+++ b/app/src/main/res/xml/method.xml
@@ -25,5 +25,7 @@
         android:supportsSwitchingToNextInputMethod="true">
     <subtype android:icon="@drawable/ic_ime_switcher_dark"
         android:imeSubtypeMode="keyboard"
+        android:imeSubtypeLocale="en_US"
+        android:languageTag="en-US"
         android:isAsciiCapable="true" />
 </input-method>


### PR DESCRIPTION
Hi,
it may not be of interest for many, but whenever the keyboard is included in an Android image as the only keyboard, this is needed to be able to enable the keyboard.

Otherwise, the option to enable it is greyed out in the Settings app.

I build Android for my phone and I noticed this including the keyboard instead of the AOSP one.

The keyboard language can be changed from the keyboard settings anyway.