### PR TITLE
Reset the subtype cycle order for more actions

### DIFF
--- a/app/src/main/java/rkr/simplekeyboard/inputmethod/latin/RichInputConnection.java
+++ b/app/src/main/java/rkr/simplekeyboard/inputmethod/latin/RichInputConnection.java
@@ -388,6 +388,7 @@ public final class RichInputConnection {
     }
 
     public void replaceText(final int startPosition, final int endPosition, CharSequence text) {
+        RichInputMethodManager.getInstance().resetSubtypeCycleOrder();
         mIC.setComposingRegion(startPosition, endPosition);
         mIC.setComposingText(text, startPosition);
         mIC.finishComposingText();
@@ -401,6 +402,7 @@ public final class RichInputConnection {
     }
 
     public void sendKeyEvent(final KeyEvent keyEvent) {
+        RichInputMethodManager.getInstance().resetSubtypeCycleOrder();
         if (DEBUG_BATCH_NESTING) checkBatchEdit();
         if (keyEvent.getAction() == KeyEvent.ACTION_DOWN) {
             if (DEBUG_PREVIOUS_TEXT) checkConsistencyForDebug();
@@ -475,6 +477,7 @@ public final class RichInputConnection {
         if (mExpectedSelStart == start && mExpectedSelEnd == end) {
             return;
         }
+        RichInputMethodManager.getInstance().resetSubtypeCycleOrder();
 
         mExpectedSelStart = start;
         mExpectedSelEnd = end;


### PR DESCRIPTION
When changing the subtype by pressing the language switch key we need to track when the subtype is used to be able to keep the order of subtypes in order of most recently used.

Currently, the subtype is only marked as being used when committing text (and when finishing the input view). The subtype isn't marked as being used when sending a key press (entering numbers, backspacing, or moving the cursor when the cursor position is unknown), performing recapitalization, or moving the cursor position with swiping. Now those actions will also mark the subtype as being used.