### PR TITLE
chore: add crowdin.yml to translate app metadata description

### DIFF
--- a/crowdin.yml
+++ b/crowdin.yml
@@ -1,7 +1,7 @@
 files:
   - source: /app/src/main/res/values/strings.xml
     translation: /app/src/main/res/values-%android_code%/%original_file_name%
-  - source: metadata/en-US/full_description.txt
-    translation: metadata/%locale%/full_description.txt
-  - source: metadata/en-US/short_description.txt
-    translation: metadata/%locale%/short_description.txt
+  - source: /metadata/en-US/full_description.txt
+    translation: /metadata/%locale%/full_description.txt
+  - source: /metadata/en-US/short_description.txt
+    translation: /metadata/%locale%/short_description.txt


### PR DESCRIPTION
The Fastlane app description also needs to be translatable, especially for F-Droid that doesn't have auto-translation. The Keyboard is intended for a wide range of people, including those who aren't programmers and doesn't know English.
To make the metadata translatable many apps added the [Crowdin Configuration YAML File](https://support.crowdin.com/developer/configuration-file/).
After the change translators will see the full_description.txt and short_description.txt in the Crowdin interface.