### PR TITLE
fastlane: slightly improve formatting for full descriptions

### DIFF
--- a/metadata/en-US/full_description.txt
+++ b/metadata/en-US/full_description.txt
@@ -1,5 +1,16 @@
-Features:
-* Small size (<1MB)
+This keyboard is created for those who only need a keyboard and nothing more.
+
+To enable the keyboard:
+
+* Open "Simple Keyboard" from your launcher
+* Enable the Simple Keyboard (default system warning about tracking will be shown)
+* Switch to Simple Keyboard from current Input Method (differs between keyboards, usually long-press space)
+* To edit Simple Keyboard settings long-press "," or open system Settings, Languages &amp; Input, Simple Keyboard.
+* You can enable/disable all the input methods in Settings, Languages &amp; Input, Manage Keyboards (differs between phones)
+
+<b>Features:</b>
+
+* Small size (&lt;1MB)
 * Adjustable keyboard height for more screen space
 * Number row
 * Swipe space to move pointer
@@ -8,14 +19,9 @@ Features:
 * Minimal permissions (only Vibrate)
 * Ads-free
 
-Feature it doesn't have and probably will never have:
+<b>Features it doesn’t have and probably will never have:</b>
+
 * Emojis
 * GIFs
 * Spell checker
 * Swipe typing
-
-To enable the keyboard:
-* Open "Simple Keyboard" from your launcher
-* Enable the Simple Keyboard (default system warning about tracking will be shown)
-* Switch to Simple Keyboard from current Input Method (differs between keyboards, usually long-press space)
-* To edit Simple Keyboard settings long-press "," or open system Settings, Languages & Input, Simple Keyboard.


### PR DESCRIPTION
This PR slightly improves formatting of the English full description, making it possible to render it as Markdown (supported e.g. at IzzyOnDroid) while keeping it compatible with places not supporting it (e.g. F-Droid.org, PlayStore). It also adds a short intro :wink: