### PR TITLE
hcesar layout - updated pontuation

### DIFF
--- a/app/src/main/res/xml/rowkeys_hcesar1.xml
+++ b/app/src/main/res/xml/rowkeys_hcesar1.xml
@@ -18,78 +18,74 @@
 */
 -->
 
-<merge xmlns:latin="http://schemas.android.com/apk/res-auto">
+<merge
+    xmlns:latin="http://schemas.android.com/apk/res-auto"
+>
     <switch>
         <case
             latin:showNumberRow="true"
             latin:showExtraChars="true">
             <Key
                 latin:keySpec="h"
-                latin:moreKeys="!text/morekeys_h"
                 latin:keyHintLabel="-"
                 latin:additionalMoreKeys="-" />
             <Key
                 latin:keySpec="c"
-                latin:moreKeys="!text/morekeys_c"
                 latin:keyHintLabel="\\"
-                latin:additionalMoreKeys="\\\\" />
+                latin:additionalMoreKeys="\\\\"
+                latin:moreKeys="!text/morekeys_c" />
             <Key
                 latin:keySpec="e"
-                latin:moreKeys="!text/morekeys_e"
                 latin:keyHintLabel="|"
-                latin:additionalMoreKeys="\\|" />
+                latin:additionalMoreKeys="\\|"
+                latin:moreKeys="!text/morekeys_e" />
             <Key
                 latin:keySpec="s"
                 latin:keyHintLabel="="
-                latin:additionalMoreKeys="="
-                latin:moreKeys="!text/morekeys_s" />
+                latin:additionalMoreKeys="=" />
             <Key
                 latin:keySpec="a"
-                latin:moreKeys="!text/morekeys_a"
                 latin:keyHintLabel="["
-                latin:additionalMoreKeys="!text/keyspec_left_square_bracket" />
+                latin:additionalMoreKeys="!text/keyspec_left_square_bracket"
+                latin:moreKeys="!text/morekeys_a" />
             <Key
                 latin:keySpec="r"
                 latin:keyHintLabel="]"
-                latin:additionalMoreKeys="!text/keyspec_right_square_bracket"
-                latin:moreKeys="!text/morekeys_r" />
+                latin:additionalMoreKeys="!text/keyspec_right_square_bracket" />
             <Key
                 latin:keySpec="o"
-                latin:moreKeys="!text/morekeys_o"
                 latin:keyHintLabel="&lt;"
-                latin:additionalMoreKeys="!text/keyspec_less_than" />
+                latin:additionalMoreKeys="!text/keyspec_less_than"
+                latin:moreKeys="!text/morekeys_o" />
             <Key
                 latin:keySpec="p"
                 latin:keyHintLabel="&gt;"
-                latin:additionalMoreKeys="!text/keyspec_greater_than"
-                latin:moreKeys="!text/morekeys_r" />
+                latin:additionalMoreKeys="!text/keyspec_greater_than" />
             <Key
                 latin:keySpec="z"
                 latin:keyHintLabel="{"
-                latin:additionalMoreKeys="!text/keyspec_left_curly_bracket"
-                latin:moreKeys="!text/morekeys_l" />
+                latin:additionalMoreKeys="!text/keyspec_left_curly_bracket" />
             <switch>
                 <case latin:keyboardLayoutSetElement="alphabetManualShifted|alphabetShiftLockShifted|alphabetShiftLocked">
                     <Key
                         latin:keySpec="«"
                         latin:keyHintLabel="}"
-                        latin:additionalMoreKeys="!text/keyspec_right_curly_bracket"
-                        latin:moreKeys="!text/morekeys_l" />
+                        latin:additionalMoreKeys="!text/keyspec_right_curly_bracket" />
                 </case>
                 <default>
                     <Key
                         latin:keySpec=","
                         latin:keyHintLabel="}"
-                        latin:additionalMoreKeys="!text/keyspec_right_curly_bracket"
-                        latin:moreKeys="!text/morekeys_l" />
+                        latin:additionalMoreKeys="!text/keyspec_right_curly_bracket,!" />
                 </default>
             </switch>
         </case>
         <case latin:showNumberRow="true">
             <Key
-                latin:keySpec="h" />				
+                latin:keySpec="h" />
             <Key
-                latin:keySpec="c" />
+                latin:keySpec="c"
+                latin:moreKeys="!text/morekeys_c" />
             <Key
                 latin:keySpec="e"
                 latin:moreKeys="!text/morekeys_e" />
@@ -102,11 +98,11 @@
                 latin:keySpec="r" />
             <Key
                 latin:keySpec="o" 
-                latin:moreKeys="!text/morekeys_o" />				
+                latin:moreKeys="!text/morekeys_o" />
             <Key
                 latin:keySpec="p" />
             <Key
-                latin:keySpec="z" />	
+                latin:keySpec="z" />
             <switch>
                 <case latin:keyboardLayoutSetElement="alphabetManualShifted|alphabetShiftLockShifted|alphabetShiftLocked">
                     <Key
@@ -114,16 +110,16 @@
                 </case>
                 <default>
                     <Key
-                        latin:keySpec="," />
+                        latin:keySpec="," 
+                        latin:moreKeys="!" />
                 </default>
             </switch>
         </case>
                <default>
             <Key
-                latin:keySpec="h" 
+                latin:keySpec="h"
                 latin:keyHintLabel="1"
-                latin:additionalMoreKeys="1"
-                latin:moreKeys="!text/morekeys_h" />				
+                latin:additionalMoreKeys="1" />
             <Key
                 latin:keySpec="c"
                 latin:keyHintLabel="2"
@@ -137,8 +133,7 @@
             <Key
                 latin:keySpec="s"
                 latin:keyHintLabel="4"
-                latin:additionalMoreKeys="4"
-                latin:moreKeys="!text/morekeys_r" />
+                latin:additionalMoreKeys="4" />
             <Key
                 latin:keySpec="a"
                 latin:keyHintLabel="5"
@@ -147,8 +142,7 @@
             <Key
                 latin:keySpec="r"
                 latin:keyHintLabel="6"
-                latin:additionalMoreKeys="6"
-                latin:moreKeys="!text/morekeys_y" />
+                latin:additionalMoreKeys="6" />
             <Key
                 latin:keySpec="o"
                 latin:keyHintLabel="7"
@@ -157,13 +151,11 @@
             <Key
                 latin:keySpec="p"
                 latin:keyHintLabel="8"
-                latin:additionalMoreKeys="8"
-                latin:moreKeys="!text/morekeys_n" />
+                latin:additionalMoreKeys="8" />
             <Key
                 latin:keySpec="z"
                 latin:keyHintLabel="9"
-                latin:additionalMoreKeys="9"
-                latin:moreKeys="!text/morekeys_l" />
+                latin:additionalMoreKeys="9" />
            <switch>
                 <case latin:keyboardLayoutSetElement="alphabetManualShifted|alphabetShiftLockShifted|alphabetShiftLocked">
                     <Key
@@ -175,9 +167,9 @@
                     <Key
                         latin:keySpec=","
                         latin:keyHintLabel="0"
-                        latin:additionalMoreKeys="0" />
+                        latin:additionalMoreKeys="0,!" />
                 </default>
-            </switch>				
+            </switch>
         </default>
     </switch>
 </merge>

--- a/app/src/main/res/xml/rowkeys_hcesar2.xml
+++ b/app/src/main/res/xml/rowkeys_hcesar2.xml
@@ -22,50 +22,44 @@
     xmlns:latin="http://schemas.android.com/apk/res-auto"
 >
     <switch>
-        <case latin:showExtraChars="true">
+        <case
+            latin:showExtraChars="true">
             <Key
                 latin:keySpec="q"
-                latin:moreKeys="!text/morekeys_q"
                 latin:keyHintLabel="\@"
                 latin:additionalMoreKeys="\@" />
             <Key
                 latin:keySpec="t"
-                latin:moreKeys="!text/morekeys_t"
                 latin:keyHintLabel="#"
-                latin:additionalMoreKeys="#"  />
+                latin:additionalMoreKeys="#" />
             <Key
                 latin:keySpec="d"
-                latin:moreKeys="!text/morekeys_d"
                 latin:keyHintLabel="$"
                 latin:additionalMoreKeys="$" />
             <Key
                 latin:keySpec="i"
-                latin:moreKeys="!text/morekeys_i"
                 latin:keyHintLabel="%"
-                latin:additionalMoreKeys="%" />
+                latin:additionalMoreKeys="%"
+                latin:moreKeys="!text/morekeys_i" />
             <Key
                 latin:keySpec="n"
-                latin:moreKeys="!text/morekeys_n"
                 latin:keyHintLabel="&amp;"
                 latin:additionalMoreKeys="&amp;" />
             <Key
                 latin:keySpec="u"
-                latin:moreKeys="!text/morekeys_u"
                 latin:keyHintLabel="-"
-                latin:additionalMoreKeys="-" />
+                latin:additionalMoreKeys="-"
+                latin:moreKeys="!text/morekeys_u" />
             <Key
                 latin:keySpec="l"
-                latin:moreKeys="!text/morekeys_l"
                 latin:keyHintLabel="+"
                 latin:additionalMoreKeys="+" />
             <Key
                 latin:keySpec="m"
-                latin:moreKeys="!text/morekeys_t"
                 latin:keyHintLabel="("
                 latin:additionalMoreKeys="(" />
             <Key
                 latin:keySpec="x"
-                latin:moreKeys="!text/morekeys_x"
                 latin:keyHintLabel=")"
                 latin:additionalMoreKeys=")" />
             <switch>
@@ -73,30 +67,25 @@
                     <Key
                         latin:keySpec="»"
                         latin:keyHintLabel="/"
-                        latin:additionalMoreKeys="/"
-                        latin:moreKeys="!text/morekeys_l" />
+                        latin:additionalMoreKeys="/" />
                 </case>
                 <default>
                     <Key
                         latin:keySpec="."
                         latin:keyHintLabel="/"
-                        latin:additionalMoreKeys="/"
-                        latin:moreKeys="!text/morekeys_l" />
+                        latin:additionalMoreKeys="/,?" />
                 </default>
             </switch>
         </case>
         <default>
-            <Key latin:keySpec="q"
-                latin:moreKeys="!text/morekeys_q" />
+            <Key latin:keySpec="q" />
             <Key
-                latin:keySpec="t"
-                latin:moreKeys="!text/morekeys_t" />
+                latin:keySpec="t" />
             <Key
-                latin:keySpec="d"
-                latin:moreKeys="!text/morekeys_d" />
+                latin:keySpec="d" />
             <Key
                 latin:keySpec="i" 
-                latin:moreKeys="!text/morekeys_i" />				
+                latin:moreKeys="!text/morekeys_i" />
             <Key
                 latin:keySpec="n" />
             <Key
@@ -105,9 +94,9 @@
             <Key
                 latin:keySpec="l" />
             <Key
-                latin:keySpec="m" />	
+                latin:keySpec="m" />
             <Key
-                latin:keySpec="x" />				
+                latin:keySpec="x" />
            <switch>
                 <case latin:keyboardLayoutSetElement="alphabetManualShifted|alphabetShiftLockShifted|alphabetShiftLocked">
                     <Key
@@ -115,10 +104,10 @@
                 </case>
                 <default>
                     <Key
-                        latin:keySpec="." />
+                        latin:keySpec="." 
+                        latin:additionalMoreKeys="?" />
                 </default>
             </switch>
         </default>
     </switch>
 </merge>
-

--- a/app/src/main/res/xml/rowkeys_hcesar3.xml
+++ b/app/src/main/res/xml/rowkeys_hcesar3.xml
@@ -22,15 +22,14 @@
     xmlns:latin="http://schemas.android.com/apk/res-auto"
 >
     <switch>
-        <case latin:showExtraChars="true">
+        <case
+            latin:showExtraChars="true">
             <Key
                 latin:keySpec="ç"
-                latin:moreKeys="!text/morekeys_c"
                 latin:keyHintLabel="*"
                 latin:additionalMoreKeys="*" />
             <Key
                 latin:keySpec="j"
-                latin:moreKeys="!text/morekeys_j"
                 latin:keyHintLabel="&quot;"
                 latin:additionalMoreKeys="&quot;" />
             <Key
@@ -47,34 +46,28 @@
                 latin:additionalMoreKeys=";" />
             <Key
                 latin:keySpec="g"
-                latin:moreKeys="!text/morekeys_g"
                 latin:keyHintLabel="!"
                 latin:additionalMoreKeys="!" />
             <Key
                 latin:keySpec="k"
-                latin:moreKeys="!text/morekeys_k"
                 latin:keyHintLabel="\?"
                 latin:additionalMoreKeys="\?" />
         </case>
         <default>
             <Key
-                latin:keySpec="ç"
-                latin:moreKeys="!text/morekeys_c" />
+                latin:keySpec="ç" />
             <Key
-                latin:keySpec="j"
-                latin:moreKeys="!text/morekeys_j" />
+                latin:keySpec="j" />
             <Key
                 latin:keySpec="b" />
             <Key
                 latin:keySpec="f" />
             <Key
-                latin:keySpec="v"
-                latin:moreKeys="!text/morekeys_v" />
+                latin:keySpec="v" />
             <Key
-                latin:keySpec="g"
-                latin:moreKeys="!text/morekeys_g" />
+                latin:keySpec="g" />
             <Key
-                latin:keySpec="k" />				
+                latin:keySpec="k" />
         </default>
     </switch>
 </merge>


### PR DESCRIPTION
organization - key code order
removed - popup from ç and not used keys
pontuation - added ! to , and ? to . like dvorak/ipad 
<img width="205" height="130" alt="jhj" src="https://github.com/user-attachments/assets/c532765e-19d2-4678-8e2a-c41923ed5152" />


