### PR TITLE
Adding International Phonetic Alphabet (IPA) layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Features:
 - Small size (<1MB)
 - Adjustable keyboard height for more screen space
 - Number row
+- International Phonetic Alphabet (IPA)
 - Swipe space to move pointer
 - Delete swipe
 - Custom theme colors
@@ -24,7 +25,12 @@ Feature it doesn't have and probably will never have:
 - Spell checker
 - Swipe typing
 
+## IPA
+This fork includes the <b>International Phonetic Alphabet (IPA)</b> as a language that can be chosen in the keyboard. It also creates a new keyboard layout for it. It contains all phonetic letters and diacritics — if you miss some, please inform me.
+It is only available as qwerty layout (adapted). Other layouts would be welcome.
+
 ## Downloads
+ATTENTION - the download links below still point to the original, not this fork.
 
 [<img src="https://f-droid.org/badge/get-it-on.png"
       alt="Get it on F-Droid"

--- a/README.md
+++ b/README.md
@@ -29,6 +29,12 @@ Feature it doesn't have and probably will never have:
 This fork includes the <b>International Phonetic Alphabet (IPA)</b> as a language that can be chosen in the keyboard. It also creates a new keyboard layout for it. It contains all phonetic letters and diacritics — if you miss some, please inform me.
 It is only available as qwerty layout (adapted). Other layouts would be welcome.
 
+<img width="408" height="303" alt="Screenshot_20260703_225401" src="https://github.com/user-attachments/assets/c6e0ef62-a830-48af-bfec-2332ad2fe1bd" />
+<img width="408" height="487" alt="Screenshot_20260703_225546" src="https://github.com/user-attachments/assets/ac1c8509-14cf-44ea-bee9-06707a553d5f" />
+<img width="474" height="306" alt="Screenshot_20260704_223718" src="https://github.com/user-attachments/assets/10d5435b-3422-4f8b-9fa2-4b1ffe7fce03" />
+<img width="474" height="286" alt="Screenshot_20260704_223732" src="https://github.com/user-attachments/assets/224aa06d-426e-42e6-b0ad-e6a63e31bb78" />
+
+
 ## Downloads
 ATTENTION - the download links below still point to the original, not this fork.
 

--- a/app/src/main/java/rkr/simplekeyboard/inputmethod/keyboard/Key.java
+++ b/app/src/main/java/rkr/simplekeyboard/inputmethod/keyboard/Key.java
@@ -2,6 +2,7 @@
  * Copyright (C) 2010 The Android Open Source Project
  * Copyright (C) 2023 Raimondas Rimkus
  * Copyright (C) 2021 wittmane
+ * Copyright (C) 2026 lgmventura
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/src/main/java/rkr/simplekeyboard/inputmethod/keyboard/Key.java
+++ b/app/src/main/java/rkr/simplekeyboard/inputmethod/keyboard/Key.java
@@ -561,7 +561,7 @@ public class Key implements Comparable<Key> {
 
     public final int selectTextSize(final KeyDrawParams params) {
         if (mLabel != null && mLabel.startsWith("◌")) {
-            return (int) (params.mLabelSize * 1.5); //params.mLargeLetterSize; // or params.mLabelSize * 1.5
+            return (int) (params.mLabelSize * 1.6); //params.mLargeLetterSize; // or params.mLabelSize * 1.5
         }
         switch (mLabelFlags & LABEL_FLAGS_FOLLOW_KEY_TEXT_RATIO_MASK) {
         case LABEL_FLAGS_FOLLOW_KEY_LETTER_RATIO:

--- a/app/src/main/java/rkr/simplekeyboard/inputmethod/keyboard/Key.java
+++ b/app/src/main/java/rkr/simplekeyboard/inputmethod/keyboard/Key.java
@@ -218,7 +218,7 @@ public class Key implements Comparable<Key> {
      */
     public Key(final String keySpec, final TypedArray keyAttr,
             final KeyStyle style, final KeyboardParams params,
-            final KeyboardRow row) {
+            final KeyboardRow row, final String androidKeyLabel) {
         // Update the row to work with the new key
         row.setCurrentKey(keyAttr, isSpacer());
 
@@ -305,10 +305,12 @@ public class Key implements Comparable<Key> {
             // code point nor as a surrogate pair.
             mLabel = new StringBuilder().appendCodePoint(code).toString();
         } else {
-            final String label = KeySpecParser.getLabel(keySpec);
-            mLabel = needsToUpcase
-                    ? StringUtils.toTitleCaseOfKeyLabel(label, localeForUpcasing)
-                    : label;
+            String labelFromSpec = KeySpecParser.getLabel(keySpec);
+            String computedLabel = needsToUpcase
+                    ? StringUtils.toTitleCaseOfKeyLabel(labelFromSpec, localeForUpcasing)
+                    : labelFromSpec;
+
+            mLabel = (androidKeyLabel != null) ? androidKeyLabel : computedLabel;
         }
         if ((mLabelFlags & LABEL_FLAGS_DISABLE_HINT_LABEL) != 0) {
             mHintLabel = null;
@@ -356,7 +358,9 @@ public class Key implements Comparable<Key> {
         final int altCode = needsToUpcase
                 ? StringUtils.toTitleCaseOfKeyCode(altCodeInAttr, localeForUpcasing)
                 : altCodeInAttr;
-        mOptionalAttributes = OptionalAttributes.newInstance(outputText, altCode);
+        String finalOutputText = outputText;
+
+        mOptionalAttributes = OptionalAttributes.newInstance(finalOutputText, altCode);
         mKeyVisualAttributes = KeyVisualAttributes.newInstance(keyAttr);
         mHashCode = computeHashCode(this);
     }
@@ -555,6 +559,9 @@ public class Key implements Comparable<Key> {
     }
 
     public final int selectTextSize(final KeyDrawParams params) {
+        if (mLabel != null && mLabel.startsWith("◌")) {
+            return params.mLargeLetterSize; // or params.mLabelSize * 1.5
+        }
         switch (mLabelFlags & LABEL_FLAGS_FOLLOW_KEY_TEXT_RATIO_MASK) {
         case LABEL_FLAGS_FOLLOW_KEY_LETTER_RATIO:
             return params.mLetterSize;
@@ -900,7 +907,7 @@ public class Key implements Comparable<Key> {
     public static class Spacer extends Key {
         public Spacer(final TypedArray keyAttr, final KeyStyle keyStyle,
                 final KeyboardParams params, final KeyboardRow row) {
-            super(null /* keySpec */, keyAttr, keyStyle, params, row);
+            super(null /* keySpec */, keyAttr, keyStyle, params, row, null);
         }
     }
 }

--- a/app/src/main/java/rkr/simplekeyboard/inputmethod/keyboard/Key.java
+++ b/app/src/main/java/rkr/simplekeyboard/inputmethod/keyboard/Key.java
@@ -560,7 +560,7 @@ public class Key implements Comparable<Key> {
 
     public final int selectTextSize(final KeyDrawParams params) {
         if (mLabel != null && mLabel.startsWith("◌")) {
-            return params.mLargeLetterSize; // or params.mLabelSize * 1.5
+            return (int) (params.mLabelSize * 1.5); //params.mLargeLetterSize; // or params.mLabelSize * 1.5
         }
         switch (mLabelFlags & LABEL_FLAGS_FOLLOW_KEY_TEXT_RATIO_MASK) {
         case LABEL_FLAGS_FOLLOW_KEY_LETTER_RATIO:

--- a/app/src/main/java/rkr/simplekeyboard/inputmethod/keyboard/KeyboardLayoutSet.java
+++ b/app/src/main/java/rkr/simplekeyboard/inputmethod/keyboard/KeyboardLayoutSet.java
@@ -272,7 +272,9 @@ public final class KeyboardLayoutSet {
         private static int getXmlId(final Resources resources, final String keyboardLayoutSetName) {
             final String packageName = resources.getResourcePackageName(
                     R.xml.keyboard_layout_set_qwerty);
-            return resources.getIdentifier(keyboardLayoutSetName, "xml", packageName);
+            int id = resources.getIdentifier(keyboardLayoutSetName, "xml", packageName);
+            Log.d("KeyboardLayoutSet", "keyboardLayoutSetName=" + keyboardLayoutSetName + " id=" + id);
+            return id;
         }
 
         private void parseKeyboardLayoutSet(final Resources res, final int resId)

--- a/app/src/main/java/rkr/simplekeyboard/inputmethod/keyboard/internal/KeyboardBuilder.java
+++ b/app/src/main/java/rkr/simplekeyboard/inputmethod/keyboard/internal/KeyboardBuilder.java
@@ -393,14 +393,17 @@ public class KeyboardBuilder<KP extends KeyboardParams> {
             if (DEBUG) startEndTag("<%s /> skipped", TAG_KEY);
             return;
         }
-        final TypedArray keyAttr = mResources.obtainAttributes(
-                Xml.asAttributeSet(parser), R.styleable.Keyboard_Key);
+        final AttributeSet attr = Xml.asAttributeSet(parser);
+        final TypedArray keyAttr = mResources.obtainAttributes(attr, R.styleable.Keyboard_Key);
         final KeyStyle keyStyle = mParams.mKeyStyles.getKeyStyle(keyAttr, parser);
         final String keySpec = keyStyle.getString(keyAttr, R.styleable.Keyboard_Key_keySpec);
         if (TextUtils.isEmpty(keySpec)) {
             throw new ParseException("Empty keySpec", parser);
         }
-        final Key key = new Key(keySpec, keyAttr, keyStyle, mParams, row);
+
+        final String keyLabel = attr.getAttributeValue("http://schemas.android.com/apk/res/android", "keyLabel");
+
+        final Key key = new Key(keySpec, keyAttr, keyStyle, mParams, row, keyLabel);
         keyAttr.recycle();
         if (DEBUG) {
             startEndTag("<%s %s moreKeys=%s />", TAG_KEY, key, Arrays.toString(key.getMoreKeys()));

--- a/app/src/main/java/rkr/simplekeyboard/inputmethod/keyboard/internal/KeyboardTextsTable.java
+++ b/app/src/main/java/rkr/simplekeyboard/inputmethod/keyboard/internal/KeyboardTextsTable.java
@@ -4475,8 +4475,8 @@ public final class KeyboardTextsTable {
         /* morekeys_j */ "\u0135",
     };
 
-    /* Locale en_IPA: International Phonetic Alphabet */
-    private static final String[] TEXTS_en_IPA = {
+    /* Locale IPA: International Phonetic Alphabet */
+    private static final String[] TEXTS_IPA = {
         // Índice 0: morekeys_a
         "æ,ɑ,ɒ,ɐ,ʌ",
         // Índice 1: morekeys_o
@@ -4541,7 +4541,7 @@ public final class KeyboardTextsTable {
         "de"     , TEXTS_de,    /*  16/ 66 German */
         "el"     , TEXTS_el,    /*   1/  5 Greek */
         "en"     , TEXTS_en,    /*   8/ 10 English */
-        "en_IPA" , TEXTS_en_IPA,/*  11/ 22 IPA */
+        "ipa"    , TEXTS_IPA,   /*  11/ 22 IPA */
         "eo"     , TEXTS_eo,    /*  26/126 Esperanto */
         "es"     , TEXTS_es,    /*   8/ 56 Spanish */
         "et_EE"  , TEXTS_et_EE, /*  22/ 27 Estonian (Estonia) */

--- a/app/src/main/java/rkr/simplekeyboard/inputmethod/keyboard/internal/KeyboardTextsTable.java
+++ b/app/src/main/java/rkr/simplekeyboard/inputmethod/keyboard/internal/KeyboardTextsTable.java
@@ -4475,6 +4475,56 @@ public final class KeyboardTextsTable {
         /* morekeys_j */ "\u0135",
     };
 
+    /* Locale en_IPA: International Phonetic Alphabet */
+    private static final String[] TEXTS_en_IPA = {
+        // Índice 0: morekeys_a
+        "æ,ɑ,ɒ,ɐ,ʌ",
+        // Índice 1: morekeys_o
+        "ɔ,ɒ,ɵ",
+        // Índice 2: morekeys_e
+        "ə,ɛ,ɜ",
+        // Índice 3: morekeys_u
+        "ʊ,uː",
+        // Índice 4: keylabel_to_alpha (deixe null para usar o padrão "ABC")
+        null,
+        // Índice 5: morekeys_i
+        "ɪ,iː,ɨ",
+        // Índice 6: morekeys_n
+        "ŋ",
+        // Índice 7: morekeys_c
+        "ç",  // ou "ʃ" se preferir
+        // Índice 8: double_quotes (não personalizado)
+        null,
+        // Índice 9: morekeys_s
+        "ʃ",
+        // Índice 10: single_quotes (não personalizado)
+        null,
+        // Índice 11: keyspec_currency (não personalizado)
+        null,
+        // Índice 12: morekeys_y (não personalizado)
+        null,
+        // Índice 13: morekeys_z
+        "ʒ",
+        // Índice 14: morekeys_d
+        "ð",
+        // Índice 15: morekeys_t
+        "θ,ð",
+        // Índice 16: morekeys_l
+        "ɫ",  // ou null
+        // Índice 17: morekeys_g
+        "ɣ",
+        // Índice 18: single_angle_quotes (não personalizado)
+        null,
+        // Índice 19: double_angle_quotes (não personalizado)
+        null,
+        // Índice 20: morekeys_r
+        "ɹ,ɾ",
+        // Índice 21: morekeys_k
+        "x",
+        // Se você quiser personalizar mais, adicione mais posições até o índice desejado.
+        // Todos os índices não definidos serão tratados como null e o padrão será usado.
+    };
+
     private static final Object[] LOCALES_AND_TEXTS = {
     // "locale", TEXT_ARRAY,  /* numberOfNonNullText/lengthOf_TEXT_ARRAY localeName */
         "DEFAULT", TEXTS_DEFAULT, /* 176/176 DEFAULT */
@@ -4491,6 +4541,7 @@ public final class KeyboardTextsTable {
         "de"     , TEXTS_de,    /*  16/ 66 German */
         "el"     , TEXTS_el,    /*   1/  5 Greek */
         "en"     , TEXTS_en,    /*   8/ 10 English */
+        "en_IPA" , TEXTS_en_IPA,/*  11/ 22 IPA */
         "eo"     , TEXTS_eo,    /*  26/126 Esperanto */
         "es"     , TEXTS_es,    /*   8/ 56 Spanish */
         "et_EE"  , TEXTS_et_EE, /*  22/ 27 Estonian (Estonia) */

--- a/app/src/main/java/rkr/simplekeyboard/inputmethod/keyboard/internal/KeyboardTextsTable.java
+++ b/app/src/main/java/rkr/simplekeyboard/inputmethod/keyboard/internal/KeyboardTextsTable.java
@@ -4476,6 +4476,9 @@ public final class KeyboardTextsTable {
     };
 
     /* Locale IPA: International Phonetic Alphabet */
+    /* This suggests an alternative use, but it is not used, since the keys are set directly in the
+    keyrows files.
+     */
     private static final String[] TEXTS_IPA = {
         // Índice 0: morekeys_a
         "æ,ɑ,ɒ,ɐ,ʌ",
@@ -4485,23 +4488,23 @@ public final class KeyboardTextsTable {
         "ə,ɛ,ɜ",
         // Índice 3: morekeys_u
         "ʊ,uː",
-        // Índice 4: keylabel_to_alpha (deixe null para usar o padrão "ABC")
+        // Índice 4: keylabel_to_alpha
         null,
         // Índice 5: morekeys_i
         "ɪ,iː,ɨ",
         // Índice 6: morekeys_n
         "ŋ",
         // Índice 7: morekeys_c
-        "ç",  // ou "ʃ" se preferir
-        // Índice 8: double_quotes (não personalizado)
+        "ç,ʃ",
+        // Índice 8:
         null,
         // Índice 9: morekeys_s
         "ʃ",
-        // Índice 10: single_quotes (não personalizado)
+        // Índice 10:
         null,
-        // Índice 11: keyspec_currency (não personalizado)
+        // Índice 11:
         null,
-        // Índice 12: morekeys_y (não personalizado)
+        // Índice 12:
         null,
         // Índice 13: morekeys_z
         "ʒ",
@@ -4510,19 +4513,17 @@ public final class KeyboardTextsTable {
         // Índice 15: morekeys_t
         "θ,ð",
         // Índice 16: morekeys_l
-        "ɫ",  // ou null
+        "ɫ",
         // Índice 17: morekeys_g
         "ɣ",
-        // Índice 18: single_angle_quotes (não personalizado)
+        // Índice 18:
         null,
-        // Índice 19: double_angle_quotes (não personalizado)
+        // Índice 19:
         null,
         // Índice 20: morekeys_r
         "ɹ,ɾ",
         // Índice 21: morekeys_k
         "x",
-        // Se você quiser personalizar mais, adicione mais posições até o índice desejado.
-        // Todos os índices não definidos serão tratados como null e o padrão será usado.
     };
 
     private static final Object[] LOCALES_AND_TEXTS = {

--- a/app/src/main/java/rkr/simplekeyboard/inputmethod/latin/utils/SubtypeLocaleUtils.java
+++ b/app/src/main/java/rkr/simplekeyboard/inputmethod/latin/utils/SubtypeLocaleUtils.java
@@ -125,7 +125,7 @@ public final class SubtypeLocaleUtils {
     private static final String LOCALE_VIETNAMESE = "vi";
     private static final String LOCALE_ZULU = "zu";
 
-    private static final String LOCALE_EN_IPA = "en_IPA";
+    private static final String LOCALE_IPA = "ipa";
 
     private static final String[] sSupportedLocales = new String[] {
             LOCALE_ENGLISH_UNITED_STATES,
@@ -208,7 +208,7 @@ public final class SubtypeLocaleUtils {
             LOCALE_VIETNAMESE,
             LOCALE_ZULU,
 
-            LOCALE_EN_IPA
+            LOCALE_IPA
     };
 
     /**
@@ -407,7 +407,7 @@ public final class SubtypeLocaleUtils {
                 case LOCALE_SWAHILI:
                 case LOCALE_VIETNAMESE:
                 case LOCALE_ZULU:
-                case LOCALE_EN_IPA:
+                case LOCALE_IPA:
                     addLayout(LAYOUT_QWERTY);
                     addGenericLayouts();
                     break;

--- a/app/src/main/java/rkr/simplekeyboard/inputmethod/latin/utils/SubtypeLocaleUtils.java
+++ b/app/src/main/java/rkr/simplekeyboard/inputmethod/latin/utils/SubtypeLocaleUtils.java
@@ -263,6 +263,8 @@ public final class SubtypeLocaleUtils {
     public static final String LAYOUT_URDU = "urdu";
     public static final String LAYOUT_UZBEK = "uzbek";
 
+    public static final String LAYOUT_IPA = "ipa";
+
     /**
      * Get a list of all of the supported subtypes for a locale.
      * @param locale the locale string for the subtypes to look up.
@@ -407,7 +409,6 @@ public final class SubtypeLocaleUtils {
                 case LOCALE_SWAHILI:
                 case LOCALE_VIETNAMESE:
                 case LOCALE_ZULU:
-                case LOCALE_IPA:
                     addLayout(LAYOUT_QWERTY);
                     addGenericLayouts();
                     break;
@@ -570,6 +571,8 @@ public final class SubtypeLocaleUtils {
                     addLayout(LAYOUT_HCESAR, R.string.subtype_hcesar);
                     addGenericLayouts();
                     break;
+                case LOCALE_IPA:
+                    addLayout(LAYOUT_IPA);
             }
             return mSubtypes;
         }

--- a/app/src/main/java/rkr/simplekeyboard/inputmethod/latin/utils/SubtypeLocaleUtils.java
+++ b/app/src/main/java/rkr/simplekeyboard/inputmethod/latin/utils/SubtypeLocaleUtils.java
@@ -125,6 +125,8 @@ public final class SubtypeLocaleUtils {
     private static final String LOCALE_VIETNAMESE = "vi";
     private static final String LOCALE_ZULU = "zu";
 
+    private static final String LOCALE_EN_IPA = "en_IPA";
+
     private static final String[] sSupportedLocales = new String[] {
             LOCALE_ENGLISH_UNITED_STATES,
             LOCALE_ENGLISH_GREAT_BRITAIN,
@@ -204,7 +206,9 @@ public final class SubtypeLocaleUtils {
             LOCALE_URDU,
             LOCALE_UZBEK_UZBEKISTAN,
             LOCALE_VIETNAMESE,
-            LOCALE_ZULU
+            LOCALE_ZULU,
+
+            LOCALE_EN_IPA
     };
 
     /**
@@ -403,6 +407,7 @@ public final class SubtypeLocaleUtils {
                 case LOCALE_SWAHILI:
                 case LOCALE_VIETNAMESE:
                 case LOCALE_ZULU:
+                case LOCALE_EN_IPA:
                     addLayout(LAYOUT_QWERTY);
                     addGenericLayouts();
                     break;

--- a/app/src/main/res/values/donottranslate.xml
+++ b/app/src/main/res/values/donottranslate.xml
@@ -50,6 +50,7 @@
         <item>workman</item>
         <item>pcqwerty</item>
         <item>abc</item>
+        <item>ipa</item>
     </string-array>
     <!-- Predefined keyboard layout display names -->
     <string-array name="predefined_layout_display_names">
@@ -62,5 +63,6 @@
         <item>Workman</item>
         <item>PC</item>
         <item>ABC</item>
+        <item>IPA (qwerty)</item>
     </string-array>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -59,7 +59,7 @@
     <string name="locale_name_en_US">English (US)</string>
     <!-- Description for Spanish (US) keyboard subtype [CHAR LIMIT=25]
          (US) should be an abbreviation of United States to fit in the CHAR LIMIT. -->
-    <string name="locale_name_en_IPA">IPA (International Phonetic Alphabet)</string>
+    <string name="locale_name_ipa">IPA (International Phonetic Alphabet)</string>
     <string name="layout_name_ipa">IPA (qwerty)</string>
 
     <string name="locale_name_es_US">Spanish (US)</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -59,6 +59,9 @@
     <string name="locale_name_en_US">English (US)</string>
     <!-- Description for Spanish (US) keyboard subtype [CHAR LIMIT=25]
          (US) should be an abbreviation of United States to fit in the CHAR LIMIT. -->
+    <string name="locale_name_en_IPA">IPA (International Phonetic Alphabet)</string>
+    <string name="layout_name_ipa">IPA (qwerty)</string>
+
     <string name="locale_name_es_US">Spanish (US)</string>
     <!-- Description for Hinglish (https://en.wikipedia.org/wiki/Hinglish) keyboard subtype [CHAR LIMIT=25] -->
     <string name="locale_name_hi_ZZ">Hinglish</string>

--- a/app/src/main/res/xml/kbd_ipa.xml
+++ b/app/src/main/res/xml/kbd_ipa.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+/*
+**
+** Copyright 2008, The Android Open Source Project
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+-->
+
+<switch xmlns:latin="http://schemas.android.com/apk/res-auto">
+    <case latin:showNumberRow="true">
+        <Keyboard
+            latin:verticalGap="@fraction/config_key_vertical_gap_5row"
+            latin:bonusHeight="@fraction/config_key_bonus_height_5row"
+            latin:rowHeight="20%p">
+            <include latin:keyboardLayout="@xml/key_styles_common" />
+            <include latin:keyboardLayout="@xml/row_qwerty0" />
+            <include latin:keyboardLayout="@xml/rows_ipa" />
+        </Keyboard>
+    </case>
+    <default>
+        <Keyboard>
+            <include latin:keyboardLayout="@xml/key_styles_common" />
+            <include latin:keyboardLayout="@xml/rows_ipa" />
+        </Keyboard>
+    </default>
+</switch>

--- a/app/src/main/res/xml/kbd_ipa.xml
+++ b/app/src/main/res/xml/kbd_ipa.xml
@@ -2,7 +2,7 @@
 <!--
 /*
 **
-** Copyright 2026, The Android Open Source Project
+** Copyright 2026, lgmventura
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/app/src/main/res/xml/kbd_ipa.xml
+++ b/app/src/main/res/xml/kbd_ipa.xml
@@ -2,7 +2,7 @@
 <!--
 /*
 **
-** Copyright 2008, The Android Open Source Project
+** Copyright 2026, The Android Open Source Project
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/app/src/main/res/xml/kbd_ipa_diacritics.xml
+++ b/app/src/main/res/xml/kbd_ipa_diacritics.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+/*
+**
+** Copyright 2026, The Android Open Source Project
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+-->
+
+<switch xmlns:latin="http://schemas.android.com/apk/res-auto">
+    <case latin:showNumberRow="true">
+        <Keyboard
+            latin:bonusHeight="@fraction/config_key_bonus_height_5row">
+            <include
+                latin:keyboardLayout="@xml/rows_ipa_diacritics" />
+        </Keyboard>
+    </case>
+    <default>
+        <Keyboard>
+            <include
+                latin:keyboardLayout="@xml/rows_ipa_diacritics" />
+        </Keyboard>
+    </default>
+</switch>

--- a/app/src/main/res/xml/kbd_ipa_diacritics.xml
+++ b/app/src/main/res/xml/kbd_ipa_diacritics.xml
@@ -2,7 +2,7 @@
 <!--
 /*
 **
-** Copyright 2026, The Android Open Source Project
+** Copyright 2026, lgmventura
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/app/src/main/res/xml/kbd_ipa_diacritics_shifted.xml
+++ b/app/src/main/res/xml/kbd_ipa_diacritics_shifted.xml
@@ -2,7 +2,7 @@
 <!--
 /*
 **
-** Copyright 2026, The Android Open Source Project
+** Copyright 2026, lgmventura
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/app/src/main/res/xml/kbd_ipa_diacritics_shifted.xml
+++ b/app/src/main/res/xml/kbd_ipa_diacritics_shifted.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+/*
+**
+** Copyright 2026, The Android Open Source Project
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+-->
+
+<switch xmlns:latin="http://schemas.android.com/apk/res-auto">
+    <case latin:showNumberRow="true">
+        <Keyboard
+            latin:bonusHeight="@fraction/config_key_bonus_height_5row">
+            <include
+                latin:keyboardLayout="@xml/rows_ipa_diacritics_shifted" />
+        </Keyboard>
+    </case>
+    <default>
+        <Keyboard>
+            <include
+                latin:keyboardLayout="@xml/rows_ipa_diacritics_shifted" />
+        </Keyboard>
+    </default>
+</switch>

--- a/app/src/main/res/xml/keyboard_layout_set_ipa.xml
+++ b/app/src/main/res/xml/keyboard_layout_set_ipa.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+/*
+**
+** Copyright 2012, The Android Open Source Project
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+-->
+
+<KeyboardLayoutSet
+    xmlns:latin="http://schemas.android.com/apk/res-auto">
+    <Element
+        latin:elementName="alphabet"
+        latin:elementKeyboard="@xml/kbd_ipa" />
+    <Element
+        latin:elementName="symbols"
+        latin:elementKeyboard="@xml/kbd_symbols" />
+    <Element
+        latin:elementName="symbolsShifted"
+        latin:elementKeyboard="@xml/kbd_symbols_shift" />
+    <Element
+        latin:elementName="phone"
+        latin:elementKeyboard="@xml/kbd_phone" />
+    <Element
+        latin:elementName="phoneSymbols"
+        latin:elementKeyboard="@xml/kbd_phone_symbols" />
+    <Element
+        latin:elementName="number"
+        latin:elementKeyboard="@xml/kbd_number" />
+</KeyboardLayoutSet>

--- a/app/src/main/res/xml/keyboard_layout_set_ipa.xml
+++ b/app/src/main/res/xml/keyboard_layout_set_ipa.xml
@@ -28,7 +28,7 @@
         latin:elementKeyboard="@xml/kbd_ipa_diacritics" />
     <Element
         latin:elementName="symbolsShifted"
-        latin:elementKeyboard="@xml/kbd_symbols_shift" />
+        latin:elementKeyboard="@xml/kbd_ipa_diacritics_shifted" />
     <Element
         latin:elementName="phone"
         latin:elementKeyboard="@xml/kbd_phone" />

--- a/app/src/main/res/xml/keyboard_layout_set_ipa.xml
+++ b/app/src/main/res/xml/keyboard_layout_set_ipa.xml
@@ -2,7 +2,7 @@
 <!--
 /*
 **
-** Copyright 2012, The Android Open Source Project
+** Copyright 2026, The Android Open Source Project
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/app/src/main/res/xml/keyboard_layout_set_ipa.xml
+++ b/app/src/main/res/xml/keyboard_layout_set_ipa.xml
@@ -25,7 +25,7 @@
         latin:elementKeyboard="@xml/kbd_ipa" />
     <Element
         latin:elementName="symbols"
-        latin:elementKeyboard="@xml/kbd_symbols" />
+        latin:elementKeyboard="@xml/kbd_ipa_diacritics" />
     <Element
         latin:elementName="symbolsShifted"
         latin:elementKeyboard="@xml/kbd_symbols_shift" />

--- a/app/src/main/res/xml/rowkeys_ipa1.xml
+++ b/app/src/main/res/xml/rowkeys_ipa1.xml
@@ -1,0 +1,161 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+/*
+**
+** Copyright 2012, The Android Open Source Project
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+-->
+
+<merge
+    xmlns:latin="http://schemas.android.com/apk/res-auto"
+>
+    <switch>
+        <case
+            latin:showNumberRow="true"
+            latin:showExtraChars="true">
+            <Key
+                latin:keySpec="!text/keyspec_q"
+                latin:keyHintLabel="_"
+                latin:additionalMoreKeys="_"
+                latin:moreKeys="!text/morekeys_q" />
+            <Key
+                latin:keySpec="!text/keyspec_w"
+                latin:keyHintLabel="\\"
+                latin:additionalMoreKeys="\\\\"
+                latin:moreKeys="!text/morekeys_w" />
+            <Key
+                latin:keySpec="e"
+                latin:keyHintLabel="|"
+                latin:additionalMoreKeys="\\|"
+                latin:moreKeys="!text/morekeys_e" />
+            <Key
+                latin:keySpec="r"
+                latin:keyHintLabel="="
+                latin:additionalMoreKeys="="
+                latin:moreKeys="!text/morekeys_r" />
+            <Key
+                latin:keySpec="t"
+                latin:keyHintLabel="["
+                latin:additionalMoreKeys="!text/keyspec_left_square_bracket"
+                latin:moreKeys="!text/morekeys_t" />
+            <Key
+                latin:keySpec="!text/keyspec_y"
+                latin:keyHintLabel="]"
+                latin:additionalMoreKeys="!text/keyspec_right_square_bracket"
+                latin:moreKeys="!text/morekeys_y" />
+            <Key
+                latin:keySpec="u"
+                latin:keyHintLabel="&lt;"
+                latin:additionalMoreKeys="!text/keyspec_less_than"
+                latin:moreKeys="!text/morekeys_u" />
+            <Key
+                latin:keySpec="i"
+                latin:keyHintLabel="&gt;"
+                latin:additionalMoreKeys="!text/keyspec_greater_than"
+                latin:moreKeys="!text/morekeys_i" />
+            <Key
+                latin:keySpec="o"
+                latin:keyHintLabel="{"
+                latin:additionalMoreKeys="!text/keyspec_left_curly_bracket"
+                latin:moreKeys="!text/morekeys_o" />
+            <Key
+                latin:keySpec="p"
+                latin:keyHintLabel="}"
+                latin:additionalMoreKeys="!text/keyspec_right_curly_bracket" />
+        </case>
+        <case latin:showNumberRow="true">
+            <Key
+                latin:keySpec="!text/keyspec_q"
+                latin:moreKeys="!text/morekeys_q" />
+            <Key
+                latin:keySpec="!text/keyspec_w"
+                latin:moreKeys="!text/morekeys_w" />
+            <Key
+                latin:keySpec="e"
+                latin:moreKeys="!text/morekeys_e" />
+            <Key
+                latin:keySpec="r"
+                latin:moreKeys="!text/morekeys_r" />
+            <Key
+                latin:keySpec="t"
+                latin:moreKeys="!text/morekeys_t" />
+            <Key
+                latin:keySpec="!text/keyspec_y"
+                latin:moreKeys="!text/morekeys_y" />
+            <Key
+                latin:keySpec="u"
+                latin:moreKeys="!text/morekeys_u" />
+            <Key
+                latin:keySpec="i"
+                latin:moreKeys="!text/morekeys_i" />
+            <Key
+                latin:keySpec="o"
+                latin:moreKeys="!text/morekeys_o" />
+            <Key
+                latin:keySpec="p" />
+        </case>
+        <default>
+            <Key
+                latin:keySpec="!text/keyspec_q"
+                latin:keyHintLabel="1"
+                latin:additionalMoreKeys="1"
+                latin:moreKeys="!text/morekeys_q" />
+            <Key
+                latin:keySpec="!text/keyspec_w"
+                latin:keyHintLabel="2"
+                latin:additionalMoreKeys="2"
+                latin:moreKeys="!text/morekeys_w" />
+            <Key
+                latin:keySpec="e"
+                latin:keyHintLabel="3"
+                latin:additionalMoreKeys="3"
+                latin:moreKeys="!text/morekeys_e" />
+            <Key
+                latin:keySpec="r"
+                latin:keyHintLabel="4"
+                latin:additionalMoreKeys="4"
+                latin:moreKeys="!text/morekeys_r" />
+            <Key
+                latin:keySpec="t"
+                latin:keyHintLabel="5"
+                latin:additionalMoreKeys="5"
+                latin:moreKeys="!text/morekeys_t" />
+            <Key
+                latin:keySpec="!text/keyspec_y"
+                latin:keyHintLabel="6"
+                latin:additionalMoreKeys="6"
+                latin:moreKeys="!text/morekeys_y" />
+            <Key
+                latin:keySpec="u"
+                latin:keyHintLabel="7"
+                latin:additionalMoreKeys="7"
+                latin:moreKeys="!text/morekeys_u" />
+            <Key
+                latin:keySpec="i"
+                latin:keyHintLabel="8"
+                latin:additionalMoreKeys="8"
+                latin:moreKeys="!text/morekeys_i" />
+            <Key
+                latin:keySpec="o"
+                latin:keyHintLabel="9"
+                latin:additionalMoreKeys="9"
+                latin:moreKeys="!text/morekeys_o" />
+            <Key
+                latin:keySpec="p"
+                latin:keyHintLabel="0"
+                latin:additionalMoreKeys="0" />
+        </default>
+    </switch>
+</merge>

--- a/app/src/main/res/xml/rowkeys_ipa1.xml
+++ b/app/src/main/res/xml/rowkeys_ipa1.xml
@@ -32,11 +32,11 @@
             <Key
                 latin:keySpec="!text/keyspec_w"
                 latin:keyHintLabel="ʍ,ɰ"
-                latin:moreKeys="ʍ,ɥ,ɰ,ʷ" /> /*"!text/morekeys_w"*/
+                latin:moreKeys="ʍ,ɥ,ɰ,ʷ,ᵚ" /> /*"!text/morekeys_w"*/
             <Key
                 latin:keySpec="e"
                 latin:keyHintLabel="ɛ,ɜ"
-                latin:moreKeys="ɛ,œ,ɜ,ø,ɘ" /> /*"!text/morekeys_e"*/
+                latin:moreKeys="ɛ,œ,ɜ,ø,ɘ,ᵉ,ᵊ,ᵋ,ᶟ" /> /*"!text/morekeys_e"*/
             <Key
                 latin:keySpec="r"
                 latin:keyHintLabel="ɾ,ʁ,ɹ"
@@ -48,19 +48,19 @@
             <Key
                 latin:keySpec="!text/keyspec_y"
                 latin:keyHintLabel="ʏ,ɥ,ɤ"
-                latin:moreKeys="ʏ,ɥ," /> /*"!text/morekeys_y"*/
+                latin:moreKeys="ʏ,ɥ,ɤ,ʸ" /> /*"!text/morekeys_y"*/
             <Key
                 latin:keySpec="u"
                 latin:keyHintLabel="ʊ,ɯ"
-                latin:moreKeys="ʊ,ɯ,ʉ" /> /*"!text/morekeys_u"*/
+                latin:moreKeys="ʊ,ɯ,ʉ,ᵘ,ᶷ,ᶶ" /> /*"!text/morekeys_u"*/
             <Key
                 latin:keySpec="i"
                 latin:keyHintLabel="ɨ,ɪ"
-                latin:moreKeys="ɨ,ɪ,ʏ" /> /*"!text/morekeys_i"*/
+                latin:moreKeys="ɨ,ɪ,ʏ,ⁱ,ᶤ,ᶦ" /> /*"!text/morekeys_i"*/
             <Key
                 latin:keySpec="o"
                 latin:keyHintLabel="ɔ,ɵ"
-                latin:moreKeys="ɔ,ɵ,ɞ,ʌ,ɒ,ɤ" /> /*"!text/morekeys_o"*/
+                latin:moreKeys="ɔ,ɵ,ɞ,ʌ,ɒ,ɤ,ᵓ,ᶺ,ᶛ" /> /*"!text/morekeys_o"*/
             <Key
                 latin:keySpec="p"
                 latin:keyHintLabel="' [ ] /"

--- a/app/src/main/res/xml/rowkeys_ipa1.xml
+++ b/app/src/main/res/xml/rowkeys_ipa1.xml
@@ -3,6 +3,7 @@
 /*
 **
 ** Copyright 2012, The Android Open Source Project
+** Copyright 2026, lgmventura
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/app/src/main/res/xml/rowkeys_ipa1.xml
+++ b/app/src/main/res/xml/rowkeys_ipa1.xml
@@ -25,46 +25,65 @@
         <case
             latin:showNumberRow="false"
             latin:showExtraChars="true">
+            <!-- q -->
             <Key
                 latin:keySpec="!text/keyspec_q"
-                latin:keyHintLabel="ʔ,ʡ"
-                latin:moreKeys="ʔ,ʡ" /> /*"!text/morekeys_q" */
+                latin:keyHintLabel="ʔ,ʡ,ʘ"
+                latin:moreKeys="ʔ,ʡ,ʘ,ǀ,ǃ,ǂ,ǁ" />
+
+            <!-- w -->
             <Key
                 latin:keySpec="!text/keyspec_w"
                 latin:keyHintLabel="ʍ,ɰ"
-                latin:moreKeys="ʍ,ɥ,ɰ,ʷ,ᵚ" /> /*"!text/morekeys_w"*/
+                latin:moreKeys="ʍ,ɥ,ɰ,ʷ,ᵚ" />
+
+            <!-- e -->
             <Key
                 latin:keySpec="e"
                 latin:keyHintLabel="ɛ,ɜ"
-                latin:moreKeys="ɛ,œ,ɜ,ø,ɘ,ᵉ,ᵊ,ᵋ,ᶟ" /> /*"!text/morekeys_e"*/
+                latin:moreKeys="ɛ,œ,ɜ,ø,ɘ,ᵉ,ᵊ,ᵋ,ᶟ" />
+
+            <!-- r -->
             <Key
                 latin:keySpec="r"
                 latin:keyHintLabel="ɾ,ʁ,ɹ"
-                latin:moreKeys="ɾ,ɹ,ɽ,ɻ,x,ɣ,χ,ʁ,ʀ,ɰ" /> /*"!text/morekeys_r"*/
+                latin:moreKeys="ɾ,ɹ,ɽ,ɻ,x,ɣ,χ,ʁ,ʀ,ɰ,ʳ,ᵡ,ʶ" />
+
+            <!-- t -->
             <Key
                 latin:keySpec="t"
                 latin:keyHintLabel="ʈ,ʦ,ʧ"
-                latin:moreKeys="ʈ,ʦ,ʧ,ꭧ,ʨ" /> /*"!text/morekeys_t"*/
+                latin:moreKeys="ʈ,ʦ,ʧ,ꭧ,ʨ,ᵗ" />
+
+            <!-- y -->
             <Key
                 latin:keySpec="!text/keyspec_y"
                 latin:keyHintLabel="ʏ,ɥ,ɤ"
-                latin:moreKeys="ʏ,ɥ,ɤ,ʸ" /> /*"!text/morekeys_y"*/
+                latin:moreKeys="ʏ,ɥ,ɤ,ʸ" />
+
+            <!-- u -->
             <Key
                 latin:keySpec="u"
                 latin:keyHintLabel="ʊ,ɯ"
-                latin:moreKeys="ʊ,ɯ,ʉ,ᵘ,ᶷ,ᶶ" /> /*"!text/morekeys_u"*/
+                latin:moreKeys="ʊ,ɯ,ʉ,ᵘ,ᶷ,ᶶ" />
+
+            <!-- i -->
             <Key
                 latin:keySpec="i"
                 latin:keyHintLabel="ɨ,ɪ"
-                latin:moreKeys="ɨ,ɪ,ʏ,ⁱ,ᶤ,ᶦ" /> /*"!text/morekeys_i"*/
+                latin:moreKeys="ɨ,ɪ,ʏ,ⁱ,ᶤ,ᶦ" />
+
+            <!-- o -->
             <Key
                 latin:keySpec="o"
                 latin:keyHintLabel="ɔ,ɵ"
-                latin:moreKeys="ɔ,ɵ,ɞ,ʌ,ɒ,ɤ,ᵓ,ᶺ,ᶛ" /> /*"!text/morekeys_o"*/
+                latin:moreKeys="ɔ,ɵ,ɞ,ʌ,ɒ,ɤ,ᵓ,ᶺ,ᶛ" />
+
+            <!-- p -->
             <Key
                 latin:keySpec="p"
                 latin:keyHintLabel="' [ ] /"
-                latin:moreKeys="',],[,/" />
+                latin:moreKeys="',],[,/,ᵖ" />
                 />
                 /*latin:keyHintLabel="}"
                 latin:additionalMoreKeys="!text/keyspec_right_curly_bracket"*/

--- a/app/src/main/res/xml/rowkeys_ipa1.xml
+++ b/app/src/main/res/xml/rowkeys_ipa1.xml
@@ -23,57 +23,51 @@
 >
     <switch>
         <case
-            latin:showNumberRow="true"
+            latin:showNumberRow="false"
             latin:showExtraChars="true">
             <Key
                 latin:keySpec="!text/keyspec_q"
-                latin:keyHintLabel="_"
-                latin:additionalMoreKeys="_"
-                latin:moreKeys="!text/morekeys_q" />
+                latin:keyHintLabel="ʔ,ʡ"
+                latin:moreKeys="ʔ,ʡ" /> /*"!text/morekeys_q" */
             <Key
                 latin:keySpec="!text/keyspec_w"
-                latin:keyHintLabel="\\"
-                latin:additionalMoreKeys="\\\\"
-                latin:moreKeys="!text/morekeys_w" />
+                latin:keyHintLabel="ʍ,ɰ"
+                latin:moreKeys="ʍ,ɥ,ɰ,ʷ" /> /*"!text/morekeys_w"*/
             <Key
                 latin:keySpec="e"
-                latin:keyHintLabel="|"
-                latin:additionalMoreKeys="\\|"
-                latin:moreKeys="!text/morekeys_e" />
+                latin:keyHintLabel="ɛ,ɜ"
+                latin:moreKeys="ɛ,œ,ɜ,ø,ɘ" /> /*"!text/morekeys_e"*/
             <Key
                 latin:keySpec="r"
-                latin:keyHintLabel="="
-                latin:additionalMoreKeys="="
-                latin:moreKeys="!text/morekeys_r" />
+                latin:keyHintLabel="ɾ,ʁ,ɹ"
+                latin:moreKeys="ɾ,ɹ,ɽ,ɻ,x,ɣ,χ,ʁ,ʀ,ɰ" /> /*"!text/morekeys_r"*/
             <Key
                 latin:keySpec="t"
-                latin:keyHintLabel="["
-                latin:additionalMoreKeys="!text/keyspec_left_square_bracket"
-                latin:moreKeys="!text/morekeys_t" />
+                latin:keyHintLabel="ʈ,ʦ,ʧ"
+                latin:moreKeys="ʈ,ʦ,ʧ,ꭧ,ʨ" /> /*"!text/morekeys_t"*/
             <Key
                 latin:keySpec="!text/keyspec_y"
-                latin:keyHintLabel="]"
-                latin:additionalMoreKeys="!text/keyspec_right_square_bracket"
-                latin:moreKeys="!text/morekeys_y" />
+                latin:keyHintLabel="ʏ,ɥ,ɤ"
+                latin:moreKeys="ʏ,ɥ," /> /*"!text/morekeys_y"*/
             <Key
                 latin:keySpec="u"
-                latin:keyHintLabel="&lt;"
-                latin:additionalMoreKeys="!text/keyspec_less_than"
-                latin:moreKeys="!text/morekeys_u" />
+                latin:keyHintLabel="ʊ,ɯ"
+                latin:moreKeys="ʊ,ɯ,ʉ" /> /*"!text/morekeys_u"*/
             <Key
                 latin:keySpec="i"
-                latin:keyHintLabel="&gt;"
-                latin:additionalMoreKeys="!text/keyspec_greater_than"
-                latin:moreKeys="!text/morekeys_i" />
+                latin:keyHintLabel="ɨ,ɪ"
+                latin:moreKeys="ɨ,ɪ,ʏ" /> /*"!text/morekeys_i"*/
             <Key
                 latin:keySpec="o"
-                latin:keyHintLabel="{"
-                latin:additionalMoreKeys="!text/keyspec_left_curly_bracket"
-                latin:moreKeys="!text/morekeys_o" />
+                latin:keyHintLabel="ɔ,ɵ"
+                latin:moreKeys="ɔ,ɵ,ɞ,ʌ,ɒ,ɤ" /> /*"!text/morekeys_o"*/
             <Key
                 latin:keySpec="p"
-                latin:keyHintLabel="}"
-                latin:additionalMoreKeys="!text/keyspec_right_curly_bracket" />
+                latin:keyHintLabel="' [ ] /"
+                latin:moreKeys="',],[,/" />
+                />
+                /*latin:keyHintLabel="}"
+                latin:additionalMoreKeys="!text/keyspec_right_curly_bracket"*/
         </case>
         <case latin:showNumberRow="true">
             <Key

--- a/app/src/main/res/xml/rowkeys_ipa1.xml
+++ b/app/src/main/res/xml/rowkeys_ipa1.xml
@@ -21,155 +21,67 @@
 
 <merge
     xmlns:latin="http://schemas.android.com/apk/res-auto"
->
-    <switch>
-        <case
-            latin:showNumberRow="false"
-            latin:showExtraChars="true">
-            <!-- q -->
-            <Key
-                latin:keySpec="!text/keyspec_q"
-                latin:keyHintLabel="ʔ,ʡ,ʘ"
-                latin:moreKeys="ʔ,ʡ,ʘ,ǀ,ǃ,ǂ,ǁ" />
+    >
+    <!-- q -->
+    <Key
+        latin:keySpec="!text/keyspec_q"
+        latin:keyHintLabel="ʔ,ʡ,ʘ"
+        latin:moreKeys="ʔ,ʡ,ʘ,ǀ,ǃ,ǂ,ǁ" />
 
-            <!-- w -->
-            <Key
-                latin:keySpec="!text/keyspec_w"
-                latin:keyHintLabel="ʍ,ɰ"
-                latin:moreKeys="ʍ,ɥ,ɰ,ʷ,ᵚ" />
+    <!-- w -->
+    <Key
+        latin:keySpec="!text/keyspec_w"
+        latin:keyHintLabel="ʍ,ɰ"
+        latin:moreKeys="ʍ,ɥ,ɰ,ʷ,ᵚ" />
 
-            <!-- e -->
-            <Key
-                latin:keySpec="e"
-                latin:keyHintLabel="ɛ,ɜ"
-                latin:moreKeys="ɛ,œ,ɜ,ø,ɘ,ᵉ,ᵊ,ᵋ,ᶟ" />
+    <!-- e -->
+    <Key
+        latin:keySpec="e"
+        latin:keyHintLabel="ɛ,ɜ"
+        latin:moreKeys="ɛ,œ,ɜ,ø,ɘ,ᵉ,ᵊ,ᵋ,ᶟ" />
 
-            <!-- r -->
-            <Key
-                latin:keySpec="r"
-                latin:keyHintLabel="ɾ,ʁ,ɹ"
-                latin:moreKeys="ɾ,ɹ,ɽ,ɻ,x,ɣ,χ,ʁ,ʀ,ɰ,ʳ,ᵡ,ʶ" />
+    <!-- r -->
+    <Key
+        latin:keySpec="r"
+        latin:keyHintLabel="ɾ,ʁ,ɹ"
+        latin:moreKeys="ɾ,ɹ,ɽ,ɻ,x,ɣ,χ,ʁ,ʀ,ɰ,ʳ,ᵡ,ʶ" />
 
-            <!-- t -->
-            <Key
-                latin:keySpec="t"
-                latin:keyHintLabel="ʈ,ʦ,ʧ"
-                latin:moreKeys="ʈ,ʦ,ʧ,ꭧ,ʨ,ᵗ" />
+    <!-- t -->
+    <Key
+        latin:keySpec="t"
+        latin:keyHintLabel="ʈ,ʦ,ʧ"
+        latin:moreKeys="ʈ,ʦ,ʧ,ꭧ,ʨ,θ,ᵗ" />
 
-            <!-- y -->
-            <Key
-                latin:keySpec="!text/keyspec_y"
-                latin:keyHintLabel="ʏ,ɥ,ɤ"
-                latin:moreKeys="ʏ,ɥ,ɤ,ʸ" />
+    <!-- y -->
+    <Key
+        latin:keySpec="!text/keyspec_y"
+        latin:keyHintLabel="ʏ,ɥ,ɤ"
+        latin:moreKeys="ʏ,ɥ,ɤ,ʸ" />
 
-            <!-- u -->
-            <Key
-                latin:keySpec="u"
-                latin:keyHintLabel="ʊ,ɯ"
-                latin:moreKeys="ʊ,ɯ,ʉ,ᵘ,ᶷ,ᶶ" />
+    <!-- u -->
+    <Key
+        latin:keySpec="u"
+        latin:keyHintLabel="ʊ,ɯ"
+        latin:moreKeys="ʊ,ɯ,ʉ,ᵘ,ᶷ,ᶶ" />
 
-            <!-- i -->
-            <Key
-                latin:keySpec="i"
-                latin:keyHintLabel="ɨ,ɪ"
-                latin:moreKeys="ɨ,ɪ,ʏ,ⁱ,ᶤ,ᶦ" />
+    <!-- i -->
+    <Key
+        latin:keySpec="i"
+        latin:keyHintLabel="ɨ,ɪ"
+        latin:moreKeys="ɨ,ɪ,ʏ,ⁱ,ᶤ,ᶦ" />
 
-            <!-- o -->
-            <Key
-                latin:keySpec="o"
-                latin:keyHintLabel="ɔ,ɵ"
-                latin:moreKeys="ɔ,ɵ,ɞ,ʌ,ɒ,ɤ,ᵓ,ᶺ,ᶛ" />
+    <!-- o -->
+    <Key
+        latin:keySpec="o"
+        latin:keyHintLabel="ɔ,ɵ"
+        latin:moreKeys="ɔ,ɵ,ɞ,ʌ,ɒ,ɤ,ᵓ,ᶺ,ᶛ" />
 
-            <!-- p -->
-            <Key
-                latin:keySpec="p"
-                latin:keyHintLabel="' [ ] /"
-                latin:moreKeys="',],[,/,ᵖ" />
-                />
-                /*latin:keyHintLabel="}"
-                latin:additionalMoreKeys="!text/keyspec_right_curly_bracket"*/
-        </case>
-        <case latin:showNumberRow="true">
-            <Key
-                latin:keySpec="!text/keyspec_q"
-                latin:moreKeys="!text/morekeys_q" />
-            <Key
-                latin:keySpec="!text/keyspec_w"
-                latin:moreKeys="!text/morekeys_w" />
-            <Key
-                latin:keySpec="e"
-                latin:moreKeys="!text/morekeys_e" />
-            <Key
-                latin:keySpec="r"
-                latin:moreKeys="!text/morekeys_r" />
-            <Key
-                latin:keySpec="t"
-                latin:moreKeys="!text/morekeys_t" />
-            <Key
-                latin:keySpec="!text/keyspec_y"
-                latin:moreKeys="!text/morekeys_y" />
-            <Key
-                latin:keySpec="u"
-                latin:moreKeys="!text/morekeys_u" />
-            <Key
-                latin:keySpec="i"
-                latin:moreKeys="!text/morekeys_i" />
-            <Key
-                latin:keySpec="o"
-                latin:moreKeys="!text/morekeys_o" />
-            <Key
-                latin:keySpec="p" />
-        </case>
-        <default>
-            <Key
-                latin:keySpec="!text/keyspec_q"
-                latin:keyHintLabel="1"
-                latin:additionalMoreKeys="1"
-                latin:moreKeys="!text/morekeys_q" />
-            <Key
-                latin:keySpec="!text/keyspec_w"
-                latin:keyHintLabel="2"
-                latin:additionalMoreKeys="2"
-                latin:moreKeys="!text/morekeys_w" />
-            <Key
-                latin:keySpec="e"
-                latin:keyHintLabel="3"
-                latin:additionalMoreKeys="3"
-                latin:moreKeys="!text/morekeys_e" />
-            <Key
-                latin:keySpec="r"
-                latin:keyHintLabel="4"
-                latin:additionalMoreKeys="4"
-                latin:moreKeys="!text/morekeys_r" />
-            <Key
-                latin:keySpec="t"
-                latin:keyHintLabel="5"
-                latin:additionalMoreKeys="5"
-                latin:moreKeys="!text/morekeys_t" />
-            <Key
-                latin:keySpec="!text/keyspec_y"
-                latin:keyHintLabel="6"
-                latin:additionalMoreKeys="6"
-                latin:moreKeys="!text/morekeys_y" />
-            <Key
-                latin:keySpec="u"
-                latin:keyHintLabel="7"
-                latin:additionalMoreKeys="7"
-                latin:moreKeys="!text/morekeys_u" />
-            <Key
-                latin:keySpec="i"
-                latin:keyHintLabel="8"
-                latin:additionalMoreKeys="8"
-                latin:moreKeys="!text/morekeys_i" />
-            <Key
-                latin:keySpec="o"
-                latin:keyHintLabel="9"
-                latin:additionalMoreKeys="9"
-                latin:moreKeys="!text/morekeys_o" />
-            <Key
-                latin:keySpec="p"
-                latin:keyHintLabel="0"
-                latin:additionalMoreKeys="0" />
-        </default>
-    </switch>
+    <!-- p -->
+    <Key
+        latin:keySpec="p"
+        latin:keyHintLabel="' [ ] /"
+        latin:moreKeys="',],[,/,ᵖ" />
+        />
+        /*latin:keyHintLabel="}"
+        latin:additionalMoreKeys="!text/keyspec_right_curly_bracket"*/
 </merge>

--- a/app/src/main/res/xml/rowkeys_ipa2.xml
+++ b/app/src/main/res/xml/rowkeys_ipa2.xml
@@ -37,13 +37,13 @@
     <Key
         latin:keySpec="d"
         latin:keyHintLabel="ð,ɖ"
-        latin:moreKeys="ð,ɖ,ɗ,ʄ,ɠ,ᶑ,ᵈ" />
+        latin:moreKeys="ð,ɖ,ɗ,ʄ,ɠ,ᶑ,ʣ,ʥ,ʤ,ᵈ" />
 
     <!-- F -->
     <Key
         latin:keySpec="f"
         latin:keyHintLabel="ɸ,θ"
-        latin:moreKeys="ɸ,θ,ʙ,ʀ,ᶠ,ᶲ" />
+        latin:moreKeys="ɸ,θ,ᶠ,ᶲ" />
 
     <!-- G -->
     <Key
@@ -73,6 +73,6 @@
     <Key
         latin:keySpec="l"
         latin:keyHintLabel="ɬ,ɮ"
-        latin:moreKeys="ɬ,ɮ,ʎ,ʟ,ɫ,ˡ,ᶫ" />
+        latin:moreKeys="ɫ,ʎ,ɬ,ɮ,ʟ,ˡ,ᶫ" />
 
 </merge>

--- a/app/src/main/res/xml/rowkeys_ipa2.xml
+++ b/app/src/main/res/xml/rowkeys_ipa2.xml
@@ -2,7 +2,7 @@
 <!--
 /*
 **
-** Copyright 2026, The Android Open Source Project
+** Copyright 2026, lgmventura
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/app/src/main/res/xml/rowkeys_ipa2.xml
+++ b/app/src/main/res/xml/rowkeys_ipa2.xml
@@ -18,73 +18,61 @@
 */
 -->
 
-<merge
-    xmlns:latin="http://schemas.android.com/apk/res-auto"
->
-    <switch>
-        <case latin:showExtraChars="true">
-            <Key latin:keySpec="a"
-                latin:keyHintLabel="ɐ,æ,ɑ"
-                latin:moreKeys="ɐ,ɑ,ɒ,æ,ʌ,ɘ,ᵃ,ᵄ,ᵅ,ᶛ,ᶺ,ᵊ" /> /*alternatively, use "!text/morekeys_a" defined in KeyboardTextsTable*/
-            <Key
-                latin:keySpec="s"
-                latin:keyHintLabel="ʃ,ʂ,ɕ"
-                latin:moreKeys="ʃ,ʂ,ɕ,ç,ʝ,ɟ" />  <!-- Fricativas e palatal -->
-            <Key
-                latin:keySpec="d"
-                latin:keyHintLabel="ð,ɖ"
-                latin:moreKeys="ð,ɖ,ɗ,ʄ,ɠ" /> <!-- Fricativa dental sonora, retroflexa e implosivas -->
-            <Key
-                latin:keySpec="f"
-                latin:keyHintLabel="ɸ,θ"
-                latin:moreKeys="ɸ,θ,f,ʙ,ʀ" /> <!-- Bilabial, dental e vibrantes -->
-            <Key
-                latin:keySpec="g"
-                latin:keyHintLabel="ɣ,ɢ,ɠ"
-                latin:moreKeys="ɣ,ɢ,ɠ,ʛ,ɰ" /> <!-- Velar, uvular e implosivas -->
-            <Key
-                latin:keySpec="h"
-                latin:keyHintLabel="ħ,ɦ"
-                latin:moreKeys="ħ,ɦ,ʜ,ʢ,ʔ" /> <!-- Faríngeas, glotais -->
-            <Key
-                latin:keySpec="j"
-                latin:keyHintLabel="ʝ,ɟ"
-                latin:moreKeys="ʝ,ɟ,ʎ,ɫ,ʒ,ʑ,ʐ,ʓ" /> <!-- Palatal e lateral velarizada, fricativas sonoras -->
-            <Key
-                latin:keySpec="k"
-                latin:keyHintLabel="x,χ"
-                latin:moreKeys="x,χ,ɧ,q,ɢ" /> <!-- Fricativas e uvular -->
-            <Key
-                latin:keySpec="l"
-                latin:keyHintLabel="ɬ,ɮ"
-                latin:moreKeys="ɬ,ɮ,ʎ,ʟ,ɫ" /> <!-- Fricativas laterais e aproximantes -->
-        </case>
-        <default>
-            <Key latin:keySpec="a"
-                latin:moreKeys="!text/morekeys_a" />
-            <Key
-                latin:keySpec="s"
-                latin:moreKeys="!text/morekeys_s" />
-            <Key
-                latin:keySpec="d"
-                latin:moreKeys="!text/morekeys_d" />
-            <Key
-                latin:keySpec="f" />
-            <Key
-                latin:keySpec="g"
-                latin:moreKeys="!text/morekeys_g" />
-            <Key
-                latin:keySpec="h"
-                latin:moreKeys="!text/morekeys_h" />
-            <Key
-                latin:keySpec="j"
-                latin:moreKeys="!text/morekeys_j" />
-            <Key
-                latin:keySpec="k"
-                latin:moreKeys="!text/morekeys_k" />
-            <Key
-                latin:keySpec="l"
-                latin:moreKeys="!text/morekeys_l" />
-        </default>
-    </switch>
+
+<merge xmlns:latin="http://schemas.android.com/apk/res-auto"
+    xmlns:android="http://schemas.android.com/apk/res/android">
+    <!-- A -->
+    <Key
+        latin:keySpec="a"
+        latin:keyHintLabel="ɐ,æ,ɑ"
+        latin:moreKeys="ɐ,ɑ,ɒ,æ,ʌ,ɘ,ᵃ,ᵄ,ᵅ,ᶛ,ᶺ,ᵊ" />
+
+    <!-- S -->
+    <Key
+        latin:keySpec="s"
+        latin:keyHintLabel="ʃ,ʂ,ɕ"
+        latin:moreKeys="ʃ,ʂ,ɕ,ç,ʝ,ɟ,ˢ,ᶴ,ᶳ,ᶽ" />
+
+    <!-- D -->
+    <Key
+        latin:keySpec="d"
+        latin:keyHintLabel="ð,ɖ"
+        latin:moreKeys="ð,ɖ,ɗ,ʄ,ɠ,ᶑ,ᵈ" />
+
+    <!-- F -->
+    <Key
+        latin:keySpec="f"
+        latin:keyHintLabel="ɸ,θ"
+        latin:moreKeys="ɸ,θ,ʙ,ʀ,ᶠ,ᶲ" />
+
+    <!-- G -->
+    <Key
+        latin:keySpec="g"
+        latin:keyHintLabel="ɣ,ɢ,ɠ"
+        latin:moreKeys="ɣ,ɢ,ɠ,ʛ,ɰ,ᶢ,ᵍ" />
+
+    <!-- H -->
+    <Key
+        latin:keySpec="h"
+        latin:keyHintLabel="ħ,ɦ"
+        latin:moreKeys="ħ,ɦ,ʜ,ʢ,ʔ,ʰ,ʱ" />
+
+    <!-- J -->
+    <Key
+        latin:keySpec="j"
+        latin:keyHintLabel="ʝ,ɟ"
+        latin:moreKeys="ʝ,ɟ,ʎ,ɫ,ʒ,ʑ,ʐ,ʓ,ʲ,ᶨ" />
+
+    <!-- K -->
+    <Key
+        latin:keySpec="k"
+        latin:keyHintLabel="x,χ"
+        latin:moreKeys="x,χ,ɧ,q,ɢ,ᶄ,ᵏ" />
+
+    <!-- L -->
+    <Key
+        latin:keySpec="l"
+        latin:keyHintLabel="ɬ,ɮ"
+        latin:moreKeys="ɬ,ɮ,ʎ,ʟ,ɫ,ˡ,ᶫ" />
+
 </merge>

--- a/app/src/main/res/xml/rowkeys_ipa2.xml
+++ b/app/src/main/res/xml/rowkeys_ipa2.xml
@@ -25,45 +25,39 @@
         <case latin:showExtraChars="true">
             <Key latin:keySpec="a"
                 latin:keyHintLabel="æ,ɑ,ɐ"
-                latin:moreKeys="æ,ɑ,ɒ,ɐ,ʌ" /> /*"!text/morekeys_a" */
+                latin:moreKeys="æ,ɑ,ɒ,ɐ,ʌ,ɘ" /> /*alternatively, use "!text/morekeys_a" defined in KeyboardTextsTable*/
             <Key
                 latin:keySpec="s"
-                latin:keyHintLabel="#"
-                latin:moreKeys="!text/morekeys_s" />
+                latin:keyHintLabel="ʃ,ʂ,ɕ"
+                latin:moreKeys="ʃ,ʂ,ɕ,ç,ʝ,ɟ" />  <!-- Fricativas e palatal -->
             <Key
                 latin:keySpec="d"
-                latin:keyHintLabel="$"
-                latin:additionalMoreKeys="$"
-                latin:moreKeys="!text/morekeys_d" />
+                latin:keyHintLabel="ð,ɖ"
+                latin:moreKeys="ð,ɖ,ɗ,ʄ,ɠ" /> <!-- Fricativa dental sonora, retroflexa e implosivas -->
             <Key
                 latin:keySpec="f"
-                latin:keyHintLabel="%"
-                latin:additionalMoreKeys="%" />
+                latin:keyHintLabel="ɸ,θ"
+                latin:moreKeys="ɸ,θ,f,ʙ,ʀ" /> <!-- Bilabial, dental e vibrantes -->
             <Key
                 latin:keySpec="g"
-                latin:keyHintLabel="&amp;"
-                latin:additionalMoreKeys="&amp;"
-                latin:moreKeys="!text/morekeys_g" />
+                latin:keyHintLabel="ɣ,ɢ,ɠ"
+                latin:moreKeys="ɣ,ɢ,ɠ,ʛ,ɰ" /> <!-- Velar, uvular e implosivas -->
             <Key
                 latin:keySpec="h"
-                latin:keyHintLabel="-"
-                latin:additionalMoreKeys="-"
-                latin:moreKeys="!text/morekeys_h" />
+                latin:keyHintLabel="ħ,ɦ"
+                latin:moreKeys="ħ,ɦ,ʜ,ʢ,ʔ" /> <!-- Faríngeas, glotais -->
             <Key
                 latin:keySpec="j"
-                latin:keyHintLabel="+"
-                latin:additionalMoreKeys="+"
-                latin:moreKeys="!text/morekeys_j" />
+                latin:keyHintLabel="ʝ,ɟ"
+                latin:moreKeys="ʝ,ɟ,ʎ,ɫ,ʒ,ʑ,ʐ,ʓ" /> <!-- Palatal e lateral velarizada, fricativas sonoras -->
             <Key
                 latin:keySpec="k"
-                latin:keyHintLabel="("
-                latin:additionalMoreKeys="("
-                latin:moreKeys="!text/morekeys_k" />
+                latin:keyHintLabel="x,χ"
+                latin:moreKeys="x,χ,ɧ,q,ɢ" /> <!-- Fricativas e uvular -->
             <Key
                 latin:keySpec="l"
-                latin:keyHintLabel=")"
-                latin:additionalMoreKeys=")"
-                latin:moreKeys="!text/morekeys_l" />
+                latin:keyHintLabel="ɬ,ɮ"
+                latin:moreKeys="ɬ,ɮ,ʎ,ʟ,ɫ" /> <!-- Fricativas laterais e aproximantes -->
         </case>
         <default>
             <Key latin:keySpec="a"

--- a/app/src/main/res/xml/rowkeys_ipa2.xml
+++ b/app/src/main/res/xml/rowkeys_ipa2.xml
@@ -24,8 +24,8 @@
     <switch>
         <case latin:showExtraChars="true">
             <Key latin:keySpec="a"
-                latin:keyHintLabel="æ,ɑ,ɐ"
-                latin:moreKeys="æ,ɑ,ɒ,ɐ,ʌ,ɘ" /> /*alternatively, use "!text/morekeys_a" defined in KeyboardTextsTable*/
+                latin:keyHintLabel="ɐ,æ,ɑ"
+                latin:moreKeys="ɐ,ɑ,ɒ,æ,ʌ,ɘ,ᵃ,ᵄ,ᵅ,ᶛ,ᶺ,ᵊ" /> /*alternatively, use "!text/morekeys_a" defined in KeyboardTextsTable*/
             <Key
                 latin:keySpec="s"
                 latin:keyHintLabel="ʃ,ʂ,ɕ"

--- a/app/src/main/res/xml/rowkeys_ipa2.xml
+++ b/app/src/main/res/xml/rowkeys_ipa2.xml
@@ -55,19 +55,19 @@
     <Key
         latin:keySpec="h"
         latin:keyHintLabel="ħ,ɦ"
-        latin:moreKeys="ħ,ɦ,ʜ,ʢ,ʔ,ʰ,ʱ" />
+        latin:moreKeys="ħ,ɦ,ɧ,ʜ,ʢ,ʔ,ʰ,ʱ" />
 
     <!-- J -->
     <Key
         latin:keySpec="j"
         latin:keyHintLabel="ʝ,ɟ"
-        latin:moreKeys="ʝ,ɟ,ʎ,ɫ,ʒ,ʑ,ʐ,ʓ,ʲ,ᶨ" />
+        latin:moreKeys="ʝ,ɟ,ʎ,ʒ,ʑ,ʐ,ʓ,ʲ,ᶨ" />
 
     <!-- K -->
     <Key
         latin:keySpec="k"
         latin:keyHintLabel="x,χ"
-        latin:moreKeys="x,χ,ɧ,q,ɢ,ᶄ,ᵏ" />
+        latin:moreKeys="x,χ,ɧ,ᶄ,ᵏ" />
 
     <!-- L -->
     <Key

--- a/app/src/main/res/xml/rowkeys_ipa2.xml
+++ b/app/src/main/res/xml/rowkeys_ipa2.xml
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+/*
+**
+** Copyright 2012, The Android Open Source Project
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+-->
+
+<merge
+    xmlns:latin="http://schemas.android.com/apk/res-auto"
+>
+    <switch>
+        <case latin:showExtraChars="true">
+            <Key latin:keySpec="a"
+                latin:keyHintLabel="æ,ɑ,ɐ"
+                latin:moreKeys="æ,ɑ,ɒ,ɐ,ʌ" /> /*"!text/morekeys_a" */
+            <Key
+                latin:keySpec="s"
+                latin:keyHintLabel="#"
+                latin:moreKeys="!text/morekeys_s" />
+            <Key
+                latin:keySpec="d"
+                latin:keyHintLabel="$"
+                latin:additionalMoreKeys="$"
+                latin:moreKeys="!text/morekeys_d" />
+            <Key
+                latin:keySpec="f"
+                latin:keyHintLabel="%"
+                latin:additionalMoreKeys="%" />
+            <Key
+                latin:keySpec="g"
+                latin:keyHintLabel="&amp;"
+                latin:additionalMoreKeys="&amp;"
+                latin:moreKeys="!text/morekeys_g" />
+            <Key
+                latin:keySpec="h"
+                latin:keyHintLabel="-"
+                latin:additionalMoreKeys="-"
+                latin:moreKeys="!text/morekeys_h" />
+            <Key
+                latin:keySpec="j"
+                latin:keyHintLabel="+"
+                latin:additionalMoreKeys="+"
+                latin:moreKeys="!text/morekeys_j" />
+            <Key
+                latin:keySpec="k"
+                latin:keyHintLabel="("
+                latin:additionalMoreKeys="("
+                latin:moreKeys="!text/morekeys_k" />
+            <Key
+                latin:keySpec="l"
+                latin:keyHintLabel=")"
+                latin:additionalMoreKeys=")"
+                latin:moreKeys="!text/morekeys_l" />
+        </case>
+        <default>
+            <Key latin:keySpec="a"
+                latin:moreKeys="!text/morekeys_a" />
+            <Key
+                latin:keySpec="s"
+                latin:moreKeys="!text/morekeys_s" />
+            <Key
+                latin:keySpec="d"
+                latin:moreKeys="!text/morekeys_d" />
+            <Key
+                latin:keySpec="f" />
+            <Key
+                latin:keySpec="g"
+                latin:moreKeys="!text/morekeys_g" />
+            <Key
+                latin:keySpec="h"
+                latin:moreKeys="!text/morekeys_h" />
+            <Key
+                latin:keySpec="j"
+                latin:moreKeys="!text/morekeys_j" />
+            <Key
+                latin:keySpec="k"
+                latin:moreKeys="!text/morekeys_k" />
+            <Key
+                latin:keySpec="l"
+                latin:moreKeys="!text/morekeys_l" />
+        </default>
+    </switch>
+</merge>

--- a/app/src/main/res/xml/rowkeys_ipa2.xml
+++ b/app/src/main/res/xml/rowkeys_ipa2.xml
@@ -2,7 +2,7 @@
 <!--
 /*
 **
-** Copyright 2012, The Android Open Source Project
+** Copyright 2026, The Android Open Source Project
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/app/src/main/res/xml/rowkeys_ipa3.xml
+++ b/app/src/main/res/xml/rowkeys_ipa3.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+/*
+**
+** Copyright 2012, The Android Open Source Project
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+-->
+
+<merge
+    xmlns:latin="http://schemas.android.com/apk/res-auto"
+>
+    <switch>
+        <case latin:showExtraChars="true">
+            <Key
+                latin:keySpec="z"
+                latin:keyHintLabel="*"
+                latin:additionalMoreKeys="*"
+                latin:moreKeys="!text/morekeys_z" />
+            <Key
+                latin:keySpec="!text/keyspec_x"
+                latin:keyHintLabel="&quot;"
+                latin:additionalMoreKeys="&quot;"
+                latin:moreKeys="!text/morekeys_x" />
+            <Key
+                latin:keySpec="c"
+                latin:keyHintLabel="&apos;"
+                latin:additionalMoreKeys="&apos;"
+                latin:moreKeys="!text/morekeys_c" />
+            <Key
+                latin:keySpec="v"
+                latin:keyHintLabel=":"
+                latin:additionalMoreKeys=":"
+                latin:moreKeys="!text/morekeys_v" />
+            <Key
+                latin:keySpec="b"
+                latin:keyHintLabel=";"
+                latin:additionalMoreKeys=";" />
+            <Key
+                latin:keySpec="n"
+                latin:keyHintLabel="!"
+                latin:additionalMoreKeys="!"
+                latin:moreKeys="!text/morekeys_n" />
+            <Key
+                latin:keySpec="m"
+                latin:keyHintLabel="\?"
+                latin:additionalMoreKeys="\\?" />
+        </case>
+        <default>
+            <Key
+                latin:keySpec="z"
+                latin:moreKeys="!text/morekeys_z" />
+            <Key
+                latin:keySpec="!text/keyspec_x"
+                latin:moreKeys="!text/morekeys_x" />
+            <Key
+                latin:keySpec="c"
+                latin:moreKeys="!text/morekeys_c" />
+            <Key
+                latin:keySpec="v"
+                latin:moreKeys="!text/morekeys_v" />
+            <Key
+                latin:keySpec="b" />
+            <Key
+                latin:keySpec="n"
+                latin:moreKeys="!text/morekeys_n" />
+            <Key
+                latin:keySpec="m" />
+        </default>
+    </switch>
+</merge>

--- a/app/src/main/res/xml/rowkeys_ipa3.xml
+++ b/app/src/main/res/xml/rowkeys_ipa3.xml
@@ -25,37 +25,32 @@
         <case latin:showExtraChars="true">
             <Key
                 latin:keySpec="z"
-                latin:keyHintLabel="*"
-                latin:additionalMoreKeys="*"
-                latin:moreKeys="!text/morekeys_z" />
+                latin:keyHintLabel="ʒ,ʑ"
+                latin:moreKeys="ʒ,ʑ,ʐ,ʓ" /> <!-- Fricativas sonoras (já temos ʃ, ʂ, ɕ em s) -->
             <Key
-                latin:keySpec="!text/keyspec_x"
-                latin:keyHintLabel="&quot;"
-                latin:additionalMoreKeys="&quot;"
-                latin:moreKeys="!text/morekeys_x" />
+                latin:keySpec="x"
+                latin:keyHintLabel="χ,ħ,ʕ"
+                latin:moreKeys="χ,ħ,ʕ,ʢ,ʜ,ɧ" /> <!-- Fricativas uvular, faríngeas e a sueca -->
             <Key
                 latin:keySpec="c"
-                latin:keyHintLabel="&apos;"
-                latin:additionalMoreKeys="&apos;"
-                latin:moreKeys="!text/morekeys_c" />
+                latin:keyHintLabel="ʨ,ʧ,ʦ"
+                latin:moreKeys="ʨ,ʧ,ʦ,ʣ,ʥ,ʤ" /> <!-- Africadas (complemento) -->
             <Key
                 latin:keySpec="v"
-                latin:keyHintLabel=":"
-                latin:additionalMoreKeys=":"
-                latin:moreKeys="!text/morekeys_v" />
+                latin:keyHintLabel="ʋ,ⱱ"
+                latin:moreKeys="ʋ,ⱱ,ɞ" /> <!-- Aproximante labiodental e vogal aberta central -->
             <Key
                 latin:keySpec="b"
-                latin:keyHintLabel=";"
-                latin:additionalMoreKeys=";" />
+                latin:keyHintLabel="ɓ,ʙ"
+                latin:moreKeys="ɓ,ʙ,ɖ" /> <!-- Implosiva bilabial e vibrante bilabial -->
             <Key
                 latin:keySpec="n"
-                latin:keyHintLabel="!"
-                latin:additionalMoreKeys="!"
-                latin:moreKeys="!text/morekeys_n" />
+                latin:keyHintLabel="ɲ,ŋ,ɴ"
+                latin:moreKeys="ɲ,ŋ,ɴ,ɳ,ɱ" /> <!-- Nasais palatal, velar, uvular, retroflexa, labiodental -->
             <Key
                 latin:keySpec="m"
-                latin:keyHintLabel="\?"
-                latin:additionalMoreKeys="\\?" />
+                latin:keyHintLabel="ɱ,ɯ"
+                latin:moreKeys="ɱ,ɯ,ɰ" /> <!-- Nasal labiodental e vogal alta posterior não-arredondada -->
         </case>
         <default>
             <Key

--- a/app/src/main/res/xml/rowkeys_ipa3.xml
+++ b/app/src/main/res/xml/rowkeys_ipa3.xml
@@ -2,7 +2,7 @@
 <!--
 /*
 **
-** Copyright 2026, The Android Open Source Project
+** Copyright 2026, lgmventura
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/app/src/main/res/xml/rowkeys_ipa3.xml
+++ b/app/src/main/res/xml/rowkeys_ipa3.xml
@@ -18,60 +18,47 @@
 */
 -->
 
-<merge
-    xmlns:latin="http://schemas.android.com/apk/res-auto"
->
-    <switch>
-        <case latin:showExtraChars="true">
-            <Key
-                latin:keySpec="z"
-                latin:keyHintLabel="ʒ,ʑ"
-                latin:moreKeys="ʒ,ʑ,ʐ,ʓ" /> <!-- Fricativas sonoras (já temos ʃ, ʂ, ɕ em s) -->
-            <Key
-                latin:keySpec="x"
-                latin:keyHintLabel="χ,ħ,ʕ"
-                latin:moreKeys="χ,ħ,ʕ,ʢ,ʜ,ɧ" /> <!-- Fricativas uvular, faríngeas e a sueca -->
-            <Key
-                latin:keySpec="c"
-                latin:keyHintLabel="ʨ,ʧ,ʦ"
-                latin:moreKeys="ʨ,ʧ,ʦ,ʣ,ʥ,ʤ" /> <!-- Africadas (complemento) -->
-            <Key
-                latin:keySpec="v"
-                latin:keyHintLabel="ʋ,ⱱ"
-                latin:moreKeys="ʋ,ⱱ,ɞ" /> <!-- Aproximante labiodental e vogal aberta central -->
-            <Key
-                latin:keySpec="b"
-                latin:keyHintLabel="ɓ,ʙ"
-                latin:moreKeys="ɓ,ʙ,ɖ" /> <!-- Implosiva bilabial e vibrante bilabial -->
-            <Key
-                latin:keySpec="n"
-                latin:keyHintLabel="ɲ,ŋ,ɴ"
-                latin:moreKeys="ɲ,ŋ,ɴ,ɳ,ɱ" /> <!-- Nasais palatal, velar, uvular, retroflexa, labiodental -->
-            <Key
-                latin:keySpec="m"
-                latin:keyHintLabel="ɱ,ɯ"
-                latin:moreKeys="ɱ,ɯ,ɰ" /> <!-- Nasal labiodental e vogal alta posterior não-arredondada -->
-        </case>
-        <default>
-            <Key
-                latin:keySpec="z"
-                latin:moreKeys="!text/morekeys_z" />
-            <Key
-                latin:keySpec="!text/keyspec_x"
-                latin:moreKeys="!text/morekeys_x" />
-            <Key
-                latin:keySpec="c"
-                latin:moreKeys="!text/morekeys_c" />
-            <Key
-                latin:keySpec="v"
-                latin:moreKeys="!text/morekeys_v" />
-            <Key
-                latin:keySpec="b" />
-            <Key
-                latin:keySpec="n"
-                latin:moreKeys="!text/morekeys_n" />
-            <Key
-                latin:keySpec="m" />
-        </default>
-    </switch>
+<merge xmlns:latin="http://schemas.android.com/apk/res-auto"
+    xmlns:android="http://schemas.android.com/apk/res/android">
+    <!-- Z -->
+    <Key
+        latin:keySpec="z"
+        latin:keyHintLabel="ʒ,ʑ"
+        latin:moreKeys="ʒ,ʑ,ʐ,ʓ,ᶻ,ᶼ" />
+
+    <!-- X -->
+    <Key
+        latin:keySpec="x"
+        latin:keyHintLabel="χ,ħ,ʕ"
+        latin:moreKeys="χ,ħ,ʕ,ʢ,ʜ,ɧ,ˣ,ᵡ" />
+
+    <!-- C -->
+    <Key
+        latin:keySpec="c"
+        latin:keyHintLabel="ʨ,ʧ,ʦ"
+        latin:moreKeys="ʨ,ʧ,ʦ,ʣ,ʥ,ʤ,ᶜ,ᶝ" />
+
+    <!-- V -->
+    <Key
+        latin:keySpec="v"
+        latin:keyHintLabel="ʋ,ⱱ"
+        latin:moreKeys="ʋ,ⱱ,ɞ,ᵛ,ᶹ" />
+
+    <!-- B -->
+    <Key
+        latin:keySpec="b"
+        latin:keyHintLabel="ɓ,ʙ"
+        latin:moreKeys="ɓ,ʙ,ɖ,ᵇ" />
+
+    <!-- N -->
+    <Key
+        latin:keySpec="n"
+        latin:keyHintLabel="ɲ,ŋ,ɴ"
+        latin:moreKeys="ɲ,ŋ,ɴ,ɳ,ɱ,ⁿ,ᶰ,ᶯ,ᶮ,ᵑ" />
+
+    <!-- M -->
+    <Key
+        latin:keySpec="m"
+        latin:keyHintLabel="ɱ,ɯ"
+        latin:moreKeys="ɱ,ɯ,ɰ,ᵐ,ᶬ" />
 </merge>

--- a/app/src/main/res/xml/rowkeys_ipa3.xml
+++ b/app/src/main/res/xml/rowkeys_ipa3.xml
@@ -2,7 +2,7 @@
 <!--
 /*
 **
-** Copyright 2012, The Android Open Source Project
+** Copyright 2026, The Android Open Source Project
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/app/src/main/res/xml/rowkeys_ipa3.xml
+++ b/app/src/main/res/xml/rowkeys_ipa3.xml
@@ -36,7 +36,7 @@
     <Key
         latin:keySpec="c"
         latin:keyHintLabel="ʨ,ʧ,ʦ"
-        latin:moreKeys="ʨ,ʧ,ʦ,ʣ,ʥ,ʤ,ᶜ,ᶝ" />
+        latin:moreKeys="ʨ,ʧ,ʦ,ᶜ,ᶝ" />
 
     <!-- V -->
     <Key

--- a/app/src/main/res/xml/rowkeys_ipa3.xml
+++ b/app/src/main/res/xml/rowkeys_ipa3.xml
@@ -48,7 +48,7 @@
     <Key
         latin:keySpec="b"
         latin:keyHintLabel="ɓ,ʙ"
-        latin:moreKeys="ɓ,ʙ,ɖ,ᵇ" />
+        latin:moreKeys="β,ɓ,ʙ,ᵇ" />
 
     <!-- N -->
     <Key

--- a/app/src/main/res/xml/rowkeys_ipa_diacritics1.xml
+++ b/app/src/main/res/xml/rowkeys_ipa_diacritics1.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+/*
+**
+** Copyright 2012, The Android Open Source Project
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+-->
+
+<merge
+    xmlns:latin="http://schemas.android.com/apk/res-auto"
+    xmlns:android="http://schemas.android.com/apk/res/android">
+    <!-- Tilde -->
+    <Key
+        latin:keyHintLabel="◌̃"
+        latin:keySpec="̃" />
+    <!-- Agudo -->
+    <Key
+        android:keyLabel="◌́"
+        latin:keySpec="́" />
+    <!-- Grave -->
+    <Key
+        android:keyLabel="◌̀"
+        latin:keySpec="̀" />
+    <!-- Circunflexo -->
+    <Key
+        android:keyLabel="◌̂"
+        latin:keySpec="̂" />
+    <!-- Trema -->
+    <Key
+        android:keyLabel="◌̈"
+        latin:keySpec="̈" />
+    <!-- Macron -->
+    <Key
+        android:keyLabel="◌̄"
+        latin:keySpec="̄" />
+    <!-- Breve -->
+    <Key
+        android:keyLabel="◌̆"
+        latin:keySpec="̆" />
+    <!-- Caron -->
+    <Key
+        android:keyLabel="◌̌"
+        latin:keySpec="̌" />
+    <!-- Anel -->
+    <Key
+        android:keyLabel="◌̊"
+        latin:keySpec="̊" />
+    <!-- Cedilha -->
+    <Key
+        android:keyLabel="◌̧"
+        latin:keySpec="̧" />
+</merge>

--- a/app/src/main/res/xml/rowkeys_ipa_diacritics1.xml
+++ b/app/src/main/res/xml/rowkeys_ipa_diacritics1.xml
@@ -2,7 +2,7 @@
 <!--
 /*
 **
-** Copyright 2026, The Android Open Source Project
+** Copyright 2026, lgmventura
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/app/src/main/res/xml/rowkeys_ipa_diacritics1.xml
+++ b/app/src/main/res/xml/rowkeys_ipa_diacritics1.xml
@@ -2,7 +2,7 @@
 <!--
 /*
 **
-** Copyright 2012, The Android Open Source Project
+** Copyright 2026, The Android Open Source Project
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/app/src/main/res/xml/rowkeys_ipa_diacritics1.xml
+++ b/app/src/main/res/xml/rowkeys_ipa_diacritics1.xml
@@ -24,39 +24,60 @@
     <!-- Tilde -->
     <Key
         android:keyLabel="◌̃"
-        latin:keySpec="̃" />
+        latin:keySpec="̃"
+        latin:keyHintLabel="◌̰ ◌͋"
+        latin:moreKeys="̰,͋,̴"
+        />
     <!-- Agudo -->
     <Key
         android:keyLabel="◌́"
-        latin:keySpec="́" />
+        latin:keySpec="́"
+        latin:keyHintLabel="◌̋"
+        latin:moreKeys="̋"
+        />
     <!-- Grave -->
     <Key
         android:keyLabel="◌̀"
-        latin:keySpec="̀" />
+        latin:keySpec="̀"
+        latin:keyHintLabel="◌̏"
+        latin:moreKeys="̏"
+        />
     <!-- Circunflexo -->
     <Key
         android:keyLabel="◌̂"
-        latin:keySpec="̂" />
+        latin:keySpec="̂"
+        latin:keyHintLabel="◌̬"
+        latin:moreKeys="̬" />
     <!-- Trema -->
     <Key
         android:keyLabel="◌̈"
-        latin:keySpec="̈" />
+        latin:keySpec="̈"
+        latin:keyHintLabel="◌̤"
+        latin:moreKeys="̤" />
     <!-- Macron -->
     <Key
         android:keyLabel="◌̄"
-        latin:keySpec="̄" />
+        latin:keySpec="̄"
+        latin:keyHintLabel="◌̠"
+        latin:moreKeys="̠" />
     <!-- Breve -->
     <Key
         android:keyLabel="◌̆"
-        latin:keySpec="̆" />
+        latin:keySpec="̆"
+        latin:keyHintLabel="◌̮ ◌̯"
+        latin:moreKeys="̮,̯,̑" />
     <!-- Caron -->
     <Key
         android:keyLabel="◌̌"
-        latin:keySpec="̌" />
+        latin:keySpec="̌"
+        latin:keyHintLabel="◌̬"
+        latin:moreKeys="̬" />
     <!-- Anel -->
     <Key
         android:keyLabel="◌̊"
-        latin:keySpec="̊" />
+        latin:keySpec="̊"
+        latin:keyHintLabel="◌̥"
+        latin:moreKeys="̥" />
     <!-- Cedilha -->
     <Key
         android:keyLabel="◌̧"

--- a/app/src/main/res/xml/rowkeys_ipa_diacritics1.xml
+++ b/app/src/main/res/xml/rowkeys_ipa_diacritics1.xml
@@ -23,7 +23,7 @@
     xmlns:android="http://schemas.android.com/apk/res/android">
     <!-- Tilde -->
     <Key
-        latin:keyHintLabel="◌̃"
+        android:keyLabel="◌̃"
         latin:keySpec="̃" />
     <!-- Agudo -->
     <Key

--- a/app/src/main/res/xml/rowkeys_ipa_diacritics2.xml
+++ b/app/src/main/res/xml/rowkeys_ipa_diacritics2.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+/*
+**
+** Copyright 2012, The Android Open Source Project
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+-->
+
+<merge
+    xmlns:latin="http://schemas.android.com/apk/res-auto"
+>
+    <switch>
+        <case
+            latin:languageCode="fa"
+        >
+            <!-- U+066C: "٬" ARABIC THOUSANDS SEPARATOR
+                 U+066B: "٫" ARABIC DECIMAL SEPARATOR -->
+            <Key
+                latin:keySpec="&#x066C;"
+                latin:keyHintLabel="\@"
+                latin:moreKeys="\@" />
+            <Key
+                latin:keySpec="&#x066B;"
+                latin:keyHintLabel="\#"
+                latin:moreKeys="\#" />
+        </case>
+        <default>
+            <Key
+                latin:keySpec="\@" />
+            <Key
+                latin:keySpec="\#"
+                latin:moreKeys="&#x2116;" /> <!-- U+2116: "№" NUMERO SIGN -->
+        </default>
+    </switch>
+    <Key
+        latin:keyStyle="currencyKeyStyle"
+        latin:keyLabelFlags="followKeyLetterRatio" />
+    <Key
+        latin:keySpec="!text/keyspec_symbols_percent"
+        latin:moreKeys="!text/morekeys_symbols_percent" />
+    <Key
+        latin:keySpec="&amp;" />
+    <!-- U+2013: "–" EN DASH
+         U+2014: "—" EM DASH
+         U+00B7: "·" MIDDLE DOT -->
+    <Key
+        latin:keySpec="-"
+        latin:moreKeys="_,&#x2013;,&#x2014;,&#x00B7;" />
+    <Key
+        latin:keySpec="+"
+        latin:moreKeys="!text/morekeys_plus" />
+    <include
+        latin:keyboardLayout="@xml/keys_parentheses" />
+</merge>

--- a/app/src/main/res/xml/rowkeys_ipa_diacritics2.xml
+++ b/app/src/main/res/xml/rowkeys_ipa_diacritics2.xml
@@ -2,7 +2,7 @@
 <!--
 /*
 **
-** Copyright 2026, The Android Open Source Project
+** Copyright 2026, lgmventura
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.
@@ -62,7 +62,7 @@
         latin:keySpec="("
         latin:keyHintLabel="⟨ ⟪"
         latin:moreKeys="⟨,⟪,｟" />
-    <!-- Colchete fechado + parênteses/chaves -->
+    <!--  -->
     <Key
         android:keyLabel=")"
         latin:keySpec=")"

--- a/app/src/main/res/xml/rowkeys_ipa_diacritics2.xml
+++ b/app/src/main/res/xml/rowkeys_ipa_diacritics2.xml
@@ -20,40 +20,31 @@
 
 <merge xmlns:latin="http://schemas.android.com/apk/res-auto"
     xmlns:android="http://schemas.android.com/apk/res/android">
-    <!-- Ogonek (U+0328) -->
-    <Key
-        android:keyLabel="◌̨"
-        latin:keySpec="̨" />
-    <!-- Ponto abaixo (U+0323) -->
-    <Key
-        android:keyLabel="◌̣"
-        latin:keySpec="̣" />
-    <!-- Ponto acima (U+0307) -->
-    <Key
-        android:keyLabel="◌̇"
-        latin:keySpec="̇" />
-    <!-- Duplo agudo (U+030B) -->
-    <Key
-        android:keyLabel="◌̋"
-        latin:keySpec="̋" />
-    <!-- Duplo grave (U+030F) -->
-    <Key
-        android:keyLabel="◌̏"
-        latin:keySpec="̏" />
-    <!-- Subscrito (U+0329) -->
-    <Key
-        android:keyLabel="◌̩"
-        latin:keySpec="̩" />
-    <!-- Meio anel direito (U+035C) -->
-    <Key
-        android:keyLabel="◌͜"
-        latin:keySpec="͜" />
-    <!-- Meio anel esquerdo (U+035B) -->
-    <Key
-        android:keyLabel="◌͛"
-        latin:keySpec="͛" />
-    <!-- Acento agudo duplo (U+034B) -->
-    <Key
-        android:keyLabel="◌͋"
-        latin:keySpec="͋" />
+    <!-- Ogonek -->
+    <Key android:keyLabel="◌̨"
+         latin:keySpec="̨" />
+    <!-- Ponto abaixo -->
+    <Key android:keyLabel="◌̣"
+         latin:keySpec="̣" />
+    <!-- Ponto acima -->
+    <Key android:keyLabel="◌̇"
+         latin:keySpec="̇" />
+    <!-- Duplo agudo -->
+    <Key android:keyLabel="◌̋"
+         latin:keySpec="̋" />
+    <!-- Duplo grave -->
+    <Key android:keyLabel="◌̏"
+         latin:keySpec="̏" />
+    <!-- Meio anel direito -->
+    <Key android:keyLabel="◌͜"
+         latin:keySpec="͜" />
+    <!-- Meio anel esquerdo -->
+    <Key android:keyLabel="◌͛"
+         latin:keySpec="͛" />
+    <!-- Acento agudo duplo -->
+    <Key android:keyLabel="◌͋"
+         latin:keySpec="͋" />
+    <!-- Anel abaixo (surdo) – movido da linha 3 -->
+    <Key android:keyLabel="◌̥"
+         latin:keySpec="̥" />
 </merge>

--- a/app/src/main/res/xml/rowkeys_ipa_diacritics2.xml
+++ b/app/src/main/res/xml/rowkeys_ipa_diacritics2.xml
@@ -20,31 +20,52 @@
 
 <merge xmlns:latin="http://schemas.android.com/apk/res-auto"
     xmlns:android="http://schemas.android.com/apk/res/android">
-    <!-- Ogonek -->
-    <Key android:keyLabel="◌̨"
-         latin:keySpec="̨" />
-    <!-- Ponto abaixo -->
-    <Key android:keyLabel="◌̣"
-         latin:keySpec="̣" />
-    <!-- Ponto acima -->
+    <!-- Combining Retroflex Hook Below; ogonek -->
+    <Key android:keyLabel="◌̢"
+        latin:keySpec="̢"
+        latin:keyHintLabel="◌̨"
+        latin:moreKeys="̨" />
+    <!-- Dot above, dot below -->
     <Key android:keyLabel="◌̇"
-         latin:keySpec="̇" />
-    <!-- Duplo agudo -->
-    <Key android:keyLabel="◌̋"
-         latin:keySpec="̋" />
-    <!-- Duplo grave -->
-    <Key android:keyLabel="◌̏"
-         latin:keySpec="̏" />
+         latin:keySpec="̇"
+         latin:keyHintLabel="◌̣"
+         latin:moreKeys="̣" />
+    <!-- Down tack (U+031E), up tack,  -->
+    <Key
+        android:keyLabel="◌̞"
+        latin:keySpec="̞"
+        latin:keyHintLabel="◌̘"
+        latin:moreKeys="̝,᷵,̘,,˔,̙" />
     <!-- Meio anel direito -->
     <Key android:keyLabel="◌͜"
-         latin:keySpec="͜" />
+         latin:keySpec="͜"
+        latin:keyHintLabel="◌͡"
+        latin:moreKeys="͡" />
     <!-- Meio anel esquerdo -->
-    <Key android:keyLabel="◌͛"
-         latin:keySpec="͛" />
-    <!-- Acento agudo duplo -->
-    <Key android:keyLabel="◌͋"
-         latin:keySpec="͋" />
-    <!-- Anel abaixo (surdo) – movido da linha 3 -->
-    <Key android:keyLabel="◌̥"
-         latin:keySpec="̥" />
+    <Key android:keyLabel="◌̼"
+         latin:keySpec="̼"
+        latin:keyHintLabel="◌˞ ◌͛"
+        latin:moreKeys="˞,͛" />
+    <Key
+        android:keyLabel="ː"
+        latin:keySpec="ː"
+        latin:keyHintLabel="◌ˑ"
+        latin:moreKeys="ˑ" />
+    <!-- Stress primário + secundário -->
+    <Key
+        android:keyLabel="ˈ"
+        latin:keySpec="ˈ"
+        latin:keyHintLabel="◌ˌ"
+        latin:moreKeys="ˌ,ʼ" />
+    <Key
+        android:keyLabel="("
+        latin:keySpec="("
+        latin:keyHintLabel="⟨ ⟪"
+        latin:moreKeys="⟨,⟪,｟" />
+    <!-- Colchete fechado + parênteses/chaves -->
+    <Key
+        android:keyLabel=")"
+        latin:keySpec=")"
+        latin:keyHintLabel="⟩ ⟫"
+        latin:moreKeys="⟩,⟫,｠" />
 </merge>

--- a/app/src/main/res/xml/rowkeys_ipa_diacritics2.xml
+++ b/app/src/main/res/xml/rowkeys_ipa_diacritics2.xml
@@ -18,49 +18,42 @@
 */
 -->
 
-<merge
-    xmlns:latin="http://schemas.android.com/apk/res-auto"
->
-    <switch>
-        <case
-            latin:languageCode="fa"
-        >
-            <!-- U+066C: "٬" ARABIC THOUSANDS SEPARATOR
-                 U+066B: "٫" ARABIC DECIMAL SEPARATOR -->
-            <Key
-                latin:keySpec="&#x066C;"
-                latin:keyHintLabel="\@"
-                latin:moreKeys="\@" />
-            <Key
-                latin:keySpec="&#x066B;"
-                latin:keyHintLabel="\#"
-                latin:moreKeys="\#" />
-        </case>
-        <default>
-            <Key
-                latin:keySpec="\@" />
-            <Key
-                latin:keySpec="\#"
-                latin:moreKeys="&#x2116;" /> <!-- U+2116: "№" NUMERO SIGN -->
-        </default>
-    </switch>
+<merge xmlns:latin="http://schemas.android.com/apk/res-auto"
+    xmlns:android="http://schemas.android.com/apk/res/android">
+    <!-- Ogonek (U+0328) -->
     <Key
-        latin:keyStyle="currencyKeyStyle"
-        latin:keyLabelFlags="followKeyLetterRatio" />
+        android:keyLabel="◌̨"
+        latin:keySpec="̨" />
+    <!-- Ponto abaixo (U+0323) -->
     <Key
-        latin:keySpec="!text/keyspec_symbols_percent"
-        latin:moreKeys="!text/morekeys_symbols_percent" />
+        android:keyLabel="◌̣"
+        latin:keySpec="̣" />
+    <!-- Ponto acima (U+0307) -->
     <Key
-        latin:keySpec="&amp;" />
-    <!-- U+2013: "–" EN DASH
-         U+2014: "—" EM DASH
-         U+00B7: "·" MIDDLE DOT -->
+        android:keyLabel="◌̇"
+        latin:keySpec="̇" />
+    <!-- Duplo agudo (U+030B) -->
     <Key
-        latin:keySpec="-"
-        latin:moreKeys="_,&#x2013;,&#x2014;,&#x00B7;" />
+        android:keyLabel="◌̋"
+        latin:keySpec="̋" />
+    <!-- Duplo grave (U+030F) -->
     <Key
-        latin:keySpec="+"
-        latin:moreKeys="!text/morekeys_plus" />
-    <include
-        latin:keyboardLayout="@xml/keys_parentheses" />
+        android:keyLabel="◌̏"
+        latin:keySpec="̏" />
+    <!-- Subscrito (U+0329) -->
+    <Key
+        android:keyLabel="◌̩"
+        latin:keySpec="̩" />
+    <!-- Meio anel direito (U+035C) -->
+    <Key
+        android:keyLabel="◌͜"
+        latin:keySpec="͜" />
+    <!-- Meio anel esquerdo (U+035B) -->
+    <Key
+        android:keyLabel="◌͛"
+        latin:keySpec="͛" />
+    <!-- Acento agudo duplo (U+034B) -->
+    <Key
+        android:keyLabel="◌͋"
+        latin:keySpec="͋" />
 </merge>

--- a/app/src/main/res/xml/rowkeys_ipa_diacritics2.xml
+++ b/app/src/main/res/xml/rowkeys_ipa_diacritics2.xml
@@ -2,7 +2,7 @@
 <!--
 /*
 **
-** Copyright 2012, The Android Open Source Project
+** Copyright 2026, The Android Open Source Project
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/app/src/main/res/xml/rowkeys_ipa_diacritics3.xml
+++ b/app/src/main/res/xml/rowkeys_ipa_diacritics3.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+/*
+**
+** Copyright 2012, The Android Open Source Project
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+-->
+
+<merge
+    xmlns:latin="http://schemas.android.com/apk/res-auto"
+>
+    <Key
+        latin:keySpec="*"
+        latin:moreKeys="!text/morekeys_star" />
+    <switch>
+        <case
+            latin:languageCode="fa"
+        >
+            <Key
+                latin:keySpec="!text/keyspec_left_double_angle_quote"
+                latin:moreKeys="!text/morekeys_double_quote" />
+            <Key
+                latin:keySpec="!text/keyspec_right_double_angle_quote"
+                latin:moreKeys="!text/morekeys_single_quote" />
+        </case>
+        <default>
+            <Key
+                latin:keySpec="&quot;"
+                latin:moreKeys="!text/morekeys_double_quote" />
+            <Key
+                latin:keySpec="\'"
+                latin:moreKeys="!text/morekeys_single_quote" />
+        </default>
+    </switch>
+    <Key
+        latin:keySpec=":" />
+    <Key
+        latin:keySpec="!text/keyspec_symbols_semicolon"
+        latin:moreKeys="!text/morekeys_symbols_semicolon" />
+    <Key
+        latin:keySpec="!"
+        latin:moreKeys="!text/morekeys_exclamation" />
+    <Key
+        latin:keySpec="!text/keyspec_symbols_question"
+        latin:moreKeys="!text/morekeys_question" />
+</merge>

--- a/app/src/main/res/xml/rowkeys_ipa_diacritics3.xml
+++ b/app/src/main/res/xml/rowkeys_ipa_diacritics3.xml
@@ -2,7 +2,7 @@
 <!--
 /*
 **
-** Copyright 2026, The Android Open Source Project
+** Copyright 2026, lgmventura
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.
@@ -20,19 +20,19 @@
 
 <merge xmlns:latin="http://schemas.android.com/apk/res-auto"
     xmlns:android="http://schemas.android.com/apk/res/android">
-    <!-- Avançado / recuado -->
+    <!--  -->
     <Key
         android:keyLabel="◌̟"
         latin:keySpec="̟"
         latin:keyHintLabel="◌̽ ◌͓"
         latin:moreKeys="̽,͓" />
-    <!-- Mais arredondado / menos arredondado -->
+    <!--  -->
     <Key
         android:keyLabel="◌̹"
         latin:keySpec="̹"
         latin:keyHintLabel="◌̜"
         latin:moreKeys="̜" />
-    <!-- Silábico / não-silábico -->
+    <!--  -->
     <Key
         android:keyLabel="◌̩"
         latin:keySpec="̩"
@@ -50,12 +50,13 @@
         latin:keySpec="̪"
         latin:keyHintLabel="◌͆"
         latin:moreKeys="͆" />
+    <!-- Colchete aberto -->
     <Key
         android:keyLabel="["
         latin:keySpec="["
         latin:keyHintLabel="{ ⟦"
         latin:moreKeys="{,⟦" />
-    <!-- Colchete fechado + parênteses/chaves -->
+    <!-- Colchete fechado -->
     <Key
         android:keyLabel="]"
         latin:keySpec="]"

--- a/app/src/main/res/xml/rowkeys_ipa_diacritics3.xml
+++ b/app/src/main/res/xml/rowkeys_ipa_diacritics3.xml
@@ -24,34 +24,41 @@
     <Key
         android:keyLabel="◌̟"
         latin:keySpec="̟"
-        latin:keyHintLabel="̠"
-        latin:moreKeys="̠" />
+        latin:keyHintLabel="◌̽ ◌͓"
+        latin:moreKeys="̽,͓" />
     <!-- Mais arredondado / menos arredondado -->
     <Key
         android:keyLabel="◌̹"
         latin:keySpec="̹"
-        latin:keyHintLabel="̜"
+        latin:keyHintLabel="◌̜"
         latin:moreKeys="̜" />
-    <!-- Surdo / sonoro / sussurrado / rangido -->
-    <Key
-        android:keyLabel="◌̥"
-        latin:keySpec="̥"
-        latin:keyHintLabel="̬,̤,̰"
-        latin:moreKeys="̬,̤,̰" />
     <!-- Silábico / não-silábico -->
     <Key
         android:keyLabel="◌̩"
         latin:keySpec="̩"
-        latin:keyHintLabel="̯"
-        latin:moreKeys="̯" />
+        latin:keyHintLabel="◌̍"
+        latin:moreKeys="̍" />
     <!-- Alveolar -->
     <Key
         android:keyLabel="◌̺"
-        latin:keySpec="̺" />
+        latin:keySpec="̺"
+        latin:keyHintLabel="◌̻ ◌̚"
+        latin:moreKeys="̻,̚" />
     <!-- Dental -->
     <Key
         android:keyLabel="◌̪"
-        latin:keySpec="̪" />
-    <Key android:keyLabel="◌̯"
-        latin:keySpec="̯" />
+        latin:keySpec="̪"
+        latin:keyHintLabel="◌͆"
+        latin:moreKeys="͆" />
+    <Key
+        android:keyLabel="["
+        latin:keySpec="["
+        latin:keyHintLabel="{ ⟦"
+        latin:moreKeys="{,⟦" />
+    <!-- Colchete fechado + parênteses/chaves -->
+    <Key
+        android:keyLabel="]"
+        latin:keySpec="]"
+        latin:keyHintLabel="} ⟧"
+        latin:moreKeys="},⟧" />
 </merge>

--- a/app/src/main/res/xml/rowkeys_ipa_diacritics3.xml
+++ b/app/src/main/res/xml/rowkeys_ipa_diacritics3.xml
@@ -20,33 +20,38 @@
 
 <merge xmlns:latin="http://schemas.android.com/apk/res-auto"
     xmlns:android="http://schemas.android.com/apk/res/android">
-    <!-- Abertura (U+031F) -->
+    <!-- Avançado / recuado -->
     <Key
         android:keyLabel="◌̟"
-        latin:keySpec="̟" />
-    <!-- Arredondamento (U+0339) -->
+        latin:keySpec="̟"
+        latin:keyHintLabel="̠"
+        latin:moreKeys="̠" />
+    <!-- Mais arredondado / menos arredondado -->
     <Key
         android:keyLabel="◌̹"
-        latin:keySpec="̹" />
-    <!-- Avançado (U+0318) – na verdade é o símbolo de avançado, mas pode ser outro -->
-    <Key
-        android:keyLabel="◌̘"
-        latin:keySpec="̘" />
-    <!-- Recuado (U+0318) – corrigindo para o símbolo correto: U+0318 é "combining left tack below"? Não, vamos usar o que faz sentido -->
-    <Key
-        android:keyLabel="◌̙"
-        latin:keySpec="̙" />
-    <!-- Anel abaixo (U+0325) -->
+        latin:keySpec="̹"
+        latin:keyHintLabel="̜"
+        latin:moreKeys="̜" />
+    <!-- Surdo / sonoro / sussurrado / rangido -->
     <Key
         android:keyLabel="◌̥"
-        latin:keySpec="̥" />
-    <!-- Não-silábico (U+032F) -->
+        latin:keySpec="̥"
+        latin:keyHintLabel="̬,̤,̰"
+        latin:moreKeys="̬,̤,̰" />
+    <!-- Silábico / não-silábico -->
     <Key
-        android:keyLabel="◌̯"
-        latin:keySpec="̯" />
-    <!-- Alveolar (U+033A) -->
+        android:keyLabel="◌̩"
+        latin:keySpec="̩"
+        latin:keyHintLabel="̯"
+        latin:moreKeys="̯" />
+    <!-- Alveolar -->
     <Key
         android:keyLabel="◌̺"
         latin:keySpec="̺" />
-    <!-- (Pode adicionar mais conforme necessário) -->
+    <!-- Dental -->
+    <Key
+        android:keyLabel="◌̪"
+        latin:keySpec="̪" />
+    <Key android:keyLabel="◌̯"
+        latin:keySpec="̯" />
 </merge>

--- a/app/src/main/res/xml/rowkeys_ipa_diacritics3.xml
+++ b/app/src/main/res/xml/rowkeys_ipa_diacritics3.xml
@@ -2,7 +2,7 @@
 <!--
 /*
 **
-** Copyright 2012, The Android Open Source Project
+** Copyright 2026, The Android Open Source Project
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/app/src/main/res/xml/rowkeys_ipa_diacritics3.xml
+++ b/app/src/main/res/xml/rowkeys_ipa_diacritics3.xml
@@ -18,41 +18,35 @@
 */
 -->
 
-<merge
-    xmlns:latin="http://schemas.android.com/apk/res-auto"
->
+<merge xmlns:latin="http://schemas.android.com/apk/res-auto"
+    xmlns:android="http://schemas.android.com/apk/res/android">
+    <!-- Abertura (U+031F) -->
     <Key
-        latin:keySpec="*"
-        latin:moreKeys="!text/morekeys_star" />
-    <switch>
-        <case
-            latin:languageCode="fa"
-        >
-            <Key
-                latin:keySpec="!text/keyspec_left_double_angle_quote"
-                latin:moreKeys="!text/morekeys_double_quote" />
-            <Key
-                latin:keySpec="!text/keyspec_right_double_angle_quote"
-                latin:moreKeys="!text/morekeys_single_quote" />
-        </case>
-        <default>
-            <Key
-                latin:keySpec="&quot;"
-                latin:moreKeys="!text/morekeys_double_quote" />
-            <Key
-                latin:keySpec="\'"
-                latin:moreKeys="!text/morekeys_single_quote" />
-        </default>
-    </switch>
+        android:keyLabel="◌̟"
+        latin:keySpec="̟" />
+    <!-- Arredondamento (U+0339) -->
     <Key
-        latin:keySpec=":" />
+        android:keyLabel="◌̹"
+        latin:keySpec="̹" />
+    <!-- Avançado (U+0318) – na verdade é o símbolo de avançado, mas pode ser outro -->
     <Key
-        latin:keySpec="!text/keyspec_symbols_semicolon"
-        latin:moreKeys="!text/morekeys_symbols_semicolon" />
+        android:keyLabel="◌̘"
+        latin:keySpec="̘" />
+    <!-- Recuado (U+0318) – corrigindo para o símbolo correto: U+0318 é "combining left tack below"? Não, vamos usar o que faz sentido -->
     <Key
-        latin:keySpec="!"
-        latin:moreKeys="!text/morekeys_exclamation" />
+        android:keyLabel="◌̙"
+        latin:keySpec="̙" />
+    <!-- Anel abaixo (U+0325) -->
     <Key
-        latin:keySpec="!text/keyspec_symbols_question"
-        latin:moreKeys="!text/morekeys_question" />
+        android:keyLabel="◌̥"
+        latin:keySpec="̥" />
+    <!-- Não-silábico (U+032F) -->
+    <Key
+        android:keyLabel="◌̯"
+        latin:keySpec="̯" />
+    <!-- Alveolar (U+033A) -->
+    <Key
+        android:keyLabel="◌̺"
+        latin:keySpec="̺" />
+    <!-- (Pode adicionar mais conforme necessário) -->
 </merge>

--- a/app/src/main/res/xml/rowkeys_ipa_diacritics_shifted1.xml
+++ b/app/src/main/res/xml/rowkeys_ipa_diacritics_shifted1.xml
@@ -2,7 +2,7 @@
 <!--
 /*
 **
-** Copyright 2026, The Android Open Source Project
+** Copyright 2026, lgmventura
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/app/src/main/res/xml/rowkeys_ipa_diacritics_shifted1.xml
+++ b/app/src/main/res/xml/rowkeys_ipa_diacritics_shifted1.xml
@@ -2,7 +2,7 @@
 <!--
 /*
 **
-** Copyright 2012, The Android Open Source Project
+** Copyright 2026, The Android Open Source Project
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/app/src/main/res/xml/rowkeys_ipa_diacritics_shifted1.xml
+++ b/app/src/main/res/xml/rowkeys_ipa_diacritics_shifted1.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+/*
+**
+** Copyright 2012, The Android Open Source Project
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+-->
+
+<merge xmlns:latin="http://schemas.android.com/apk/res-auto"
+xmlns:android="http://schemas.android.com/apk/res/android">
+<Key
+    android:keyLabel="◌ʰ"
+    latin:keySpec="ʰ" />
+<Key
+    android:keyLabel="◌ʱ"
+    latin:keySpec="ʱ" />
+<Key
+    android:keyLabel="◌ʲ"
+    latin:keySpec="ʲ" />
+<Key
+    android:keyLabel="◌ʷ"
+    latin:keySpec="ʷ" />
+<Key
+    android:keyLabel="◌ˠ"
+    latin:keySpec="ˠ" />
+<Key
+    android:keyLabel="◌ˀ"
+    latin:keySpec="ˀ" />
+<Key
+    android:keyLabel="◌ˁ"
+    latin:keySpec="ˁ" />
+<Key
+    android:keyLabel="◌ˤ"
+    latin:keySpec="ˤ" />
+<Key
+    android:keyLabel="◌ᵊ"
+    latin:keySpec="ᵊ" />
+<Key
+    android:keyLabel="◌ⁿ"
+    latin:keySpec="ⁿ" />
+</merge>

--- a/app/src/main/res/xml/rowkeys_ipa_diacritics_shifted2.xml
+++ b/app/src/main/res/xml/rowkeys_ipa_diacritics_shifted2.xml
@@ -20,24 +20,33 @@
 
 <merge xmlns:latin="http://schemas.android.com/apk/res-auto"
     xmlns:android="http://schemas.android.com/apk/res/android">
-    <!-- Stress primário + secundário -->
-    <Key
-        android:keyLabel="ˈ"
-        latin:keySpec="ˈ"
-        latin:keyHintLabel="◌ˌ"
-        latin:moreKeys="ˌ" />
-    <!-- Duração longa + meia-longa -->
-    <Key
-        android:keyLabel="ː"
-        latin:keySpec="ː"
-        latin:keyHintLabel="◌ˑ"
-        latin:moreKeys="ˑ" />
+
     <!-- Tom alto + outros níveis e contornos -->
     <Key
         android:keyLabel="˥"
         latin:keySpec="˥"
-        latin:keyHintLabel="˦,˧,˨"
-        latin:moreKeys="˦,˧,˨,˩,↗,↘" />
+        latin:keyHintLabel="↗ ↘"
+        latin:moreKeys="↗,↘" />
+    <Key
+        android:keyLabel="˦"
+        latin:keySpec="˦"
+        latin:keyHintLabel=""
+        latin:moreKeys="" />
+    <Key
+        android:keyLabel="˧"
+        latin:keySpec="˧"
+        latin:keyHintLabel=""
+        latin:moreKeys="" />
+    <Key
+        android:keyLabel="˨"
+        latin:keySpec="˨"
+        latin:keyHintLabel=""
+        latin:moreKeys="" />
+    <Key
+        android:keyLabel="˩"
+        latin:keySpec="˩"
+        latin:keyHintLabel=""
+        latin:moreKeys="" />
     <!-- Barra simples + dupla -->
     <Key
         android:keyLabel="|"
@@ -52,18 +61,15 @@
         latin:moreKeys="͡,͜" />
     <!-- Colchete aberto + parênteses/chaves -->
     <Key
-        android:keyLabel="["
-        latin:keySpec="["
-        latin:keyHintLabel="(,{"
-        latin:moreKeys="(,{" />
+        android:keyLabel="&lt;"
+        latin:keySpec="&lt;"
+        latin:keyHintLabel="« ª"
+        latin:moreKeys="«,＜,ª" />
     <!-- Colchete fechado + parênteses/chaves -->
     <Key
-        android:keyLabel="]"
-        latin:keySpec="]"
-        latin:keyHintLabel="),}"
-        latin:moreKeys="),}" />
-    <!-- Símbolo de sílaba tônica -->
-    <Key
-        android:keyLabel="."
-        latin:keySpec="." />
+        android:keyLabel="&gt;"
+        latin:keySpec="&gt;"
+        latin:keyHintLabel="» º"
+        latin:moreKeys="»,＞,º" />
+    <!-- -->
 </merge>

--- a/app/src/main/res/xml/rowkeys_ipa_diacritics_shifted2.xml
+++ b/app/src/main/res/xml/rowkeys_ipa_diacritics_shifted2.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+/*
+**
+** Copyright 2012, The Android Open Source Project
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+-->
+
+<merge xmlns:latin="http://schemas.android.com/apk/res-auto"
+    xmlns:android="http://schemas.android.com/apk/res/android">
+    <!-- Stress primário + secundário -->
+    <Key
+        android:keyLabel="ˈ"
+        latin:keySpec="ˈ"
+        latin:keyHintLabel="◌ˌ"
+        latin:moreKeys="ˌ" />
+    <!-- Duração longa + meia-longa -->
+    <Key
+        android:keyLabel="ː"
+        latin:keySpec="ː"
+        latin:keyHintLabel="◌ˑ"
+        latin:moreKeys="ˑ" />
+    <!-- Tom alto + outros níveis e contornos -->
+    <Key
+        android:keyLabel="˥"
+        latin:keySpec="˥"
+        latin:keyHintLabel="˦,˧,˨"
+        latin:moreKeys="˦,˧,˨,˩,↗,↘" />
+    <!-- Barra simples + dupla -->
+    <Key
+        android:keyLabel="|"
+        latin:keySpec="|"
+        latin:keyHintLabel="‖"
+        latin:moreKeys="‖" />
+    <!-- Ligadura (linker) + arco + tie bar -->
+    <Key
+        android:keyLabel="‿"
+        latin:keySpec="‿"
+        latin:keyHintLabel="͡,͜"
+        latin:moreKeys="͡,͜" />
+    <!-- Colchete aberto + parênteses/chaves -->
+    <Key
+        android:keyLabel="["
+        latin:keySpec="["
+        latin:keyHintLabel="(,{"
+        latin:moreKeys="(,{" />
+    <!-- Colchete fechado + parênteses/chaves -->
+    <Key
+        android:keyLabel="]"
+        latin:keySpec="]"
+        latin:keyHintLabel="),}"
+        latin:moreKeys="),}" />
+    <!-- Símbolo de sílaba tônica -->
+    <Key
+        android:keyLabel="."
+        latin:keySpec="." />
+</merge>

--- a/app/src/main/res/xml/rowkeys_ipa_diacritics_shifted2.xml
+++ b/app/src/main/res/xml/rowkeys_ipa_diacritics_shifted2.xml
@@ -2,7 +2,7 @@
 <!--
 /*
 **
-** Copyright 2012, The Android Open Source Project
+** Copyright 2026, The Android Open Source Project
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/app/src/main/res/xml/rowkeys_ipa_diacritics_shifted2.xml
+++ b/app/src/main/res/xml/rowkeys_ipa_diacritics_shifted2.xml
@@ -2,7 +2,7 @@
 <!--
 /*
 **
-** Copyright 2026, The Android Open Source Project
+** Copyright 2026, lgmventura
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@
 <merge xmlns:latin="http://schemas.android.com/apk/res-auto"
     xmlns:android="http://schemas.android.com/apk/res/android">
 
-    <!-- Tom alto + outros níveis e contornos -->
+    <!-- Tons -->
     <Key
         android:keyLabel="˥"
         latin:keySpec="˥"
@@ -47,7 +47,7 @@
         latin:keySpec="˩"
         latin:keyHintLabel=""
         latin:moreKeys="" />
-    <!-- Barra simples + dupla -->
+    <!--  -->
     <Key
         android:keyLabel="|"
         latin:keySpec="|"
@@ -59,13 +59,13 @@
         latin:keySpec="‿"
         latin:keyHintLabel="͡,͜"
         latin:moreKeys="͡,͜" />
-    <!-- Colchete aberto + parênteses/chaves -->
+    <!-- less than -->
     <Key
         android:keyLabel="&lt;"
         latin:keySpec="&lt;"
         latin:keyHintLabel="« ª"
         latin:moreKeys="«,＜,ª" />
-    <!-- Colchete fechado + parênteses/chaves -->
+    <!-- greater than -->
     <Key
         android:keyLabel="&gt;"
         latin:keySpec="&gt;"

--- a/app/src/main/res/xml/rowkeys_ipa_diacritics_shifted3.xml
+++ b/app/src/main/res/xml/rowkeys_ipa_diacritics_shifted3.xml
@@ -2,7 +2,7 @@
 <!--
 /*
 **
-** Copyright 2026, The Android Open Source Project
+** Copyright 2026, lgmventura
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.
@@ -20,8 +20,7 @@
 
 <merge xmlns:latin="http://schemas.android.com/apk/res-auto"
     xmlns:android="http://schemas.android.com/apk/res/android">
-    <!-- Plosiva não audível -->
-
+    <!--  -->
     <Key
         android:keyLabel="\\"
         latin:keySpec="\\"
@@ -37,12 +36,11 @@
         latin:keySpec="×"
         latin:keyHintLabel="÷"
         latin:moreKeys="÷" />
-    <!-- Barra inclinada -->
+    <!--  -->
     <Key android:keyLabel="+"
          latin:keySpec="+" />
     <Key android:keyLabel="-"
         latin:keySpec="-" />
     <Key android:keyLabel="="
         latin:keySpec="=" />
-    <!-- etc. -->
 </merge>

--- a/app/src/main/res/xml/rowkeys_ipa_diacritics_shifted3.xml
+++ b/app/src/main/res/xml/rowkeys_ipa_diacritics_shifted3.xml
@@ -2,7 +2,7 @@
 <!--
 /*
 **
-** Copyright 2012, The Android Open Source Project
+** Copyright 2026, The Android Open Source Project
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/app/src/main/res/xml/rowkeys_ipa_diacritics_shifted3.xml
+++ b/app/src/main/res/xml/rowkeys_ipa_diacritics_shifted3.xml
@@ -21,18 +21,28 @@
 <merge xmlns:latin="http://schemas.android.com/apk/res-auto"
     xmlns:android="http://schemas.android.com/apk/res/android">
     <!-- Plosiva não audível -->
-    <Key android:keyLabel="◌̚"
-         latin:keySpec="̚" />
+
+    <Key
+        android:keyLabel="\\"
+        latin:keySpec="\\"
+        latin:keyHintLabel="↵"
+        latin:moreKeys="↵" />
     <Key android:keyLabel="·"
-         latin:keySpec="·" />
+         latin:keySpec="·"
+        latin:keyHintLabel="←↑→↓"
+        latin:moreKeys="←,↑,→,↓,↔,↕" />
     <Key android:keyLabel="*"
          latin:keySpec="*" />
     <Key android:keyLabel="×"
-        latin:keySpec="×" />
+        latin:keySpec="×"
+        latin:keyHintLabel="÷"
+        latin:moreKeys="÷" />
     <!-- Barra inclinada -->
     <Key android:keyLabel="+"
          latin:keySpec="+" />
     <Key android:keyLabel="-"
         latin:keySpec="-" />
+    <Key android:keyLabel="="
+        latin:keySpec="=" />
     <!-- etc. -->
 </merge>

--- a/app/src/main/res/xml/rowkeys_ipa_diacritics_shifted3.xml
+++ b/app/src/main/res/xml/rowkeys_ipa_diacritics_shifted3.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+/*
+**
+** Copyright 2012, The Android Open Source Project
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+-->
+
+<merge xmlns:latin="http://schemas.android.com/apk/res-auto"
+    xmlns:android="http://schemas.android.com/apk/res/android">
+    <!-- Plosiva não audível -->
+    <Key android:keyLabel="◌̚"
+         latin:keySpec="̚" />
+    <Key android:keyLabel="·"
+         latin:keySpec="·" />
+    <Key android:keyLabel="*"
+         latin:keySpec="*" />
+    <Key android:keyLabel="×"
+        latin:keySpec="×" />
+    <!-- Barra inclinada -->
+    <Key android:keyLabel="+"
+         latin:keySpec="+" />
+    <Key android:keyLabel="-"
+        latin:keySpec="-" />
+    <!-- etc. -->
+</merge>

--- a/app/src/main/res/xml/rows_ipa.xml
+++ b/app/src/main/res/xml/rows_ipa.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+/*
+**
+** Copyright 2010, The Android Open Source Project
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+-->
+
+<merge xmlns:latin="http://schemas.android.com/apk/res-auto">
+    <Row
+        latin:keyWidth="10%p"
+    >
+        <include
+            latin:keyboardLayout="@xml/rowkeys_ipa1" />
+    </Row>
+    <Row
+        latin:keyWidth="10%p"
+    >
+        <include
+            latin:keyboardLayout="@xml/rowkeys_ipa2"
+            latin:keyXPos="5%p" />
+    </Row>
+    <Row
+        latin:keyWidth="10%p"
+    >
+        <Key
+            latin:keyStyle="shiftKeyStyle"
+            latin:keyWidth="14%p" />
+        <include
+            latin:keyXPos="15%p"
+            latin:keyboardLayout="@xml/rowkeys_ipa3" />
+        <Key
+            latin:keyStyle="deleteKeyStyle"
+            latin:keyXPos="86%p"
+            latin:keyWidth="14%p" />
+    </Row>
+    <include
+        latin:keyboardLayout="@xml/row_qwerty4" />
+</merge>

--- a/app/src/main/res/xml/rows_ipa.xml
+++ b/app/src/main/res/xml/rows_ipa.xml
@@ -2,7 +2,7 @@
 <!--
 /*
 **
-** Copyright 2010, The Android Open Source Project
+** Copyright 2026, lgmventura
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/app/src/main/res/xml/rows_ipa_diacritics.xml
+++ b/app/src/main/res/xml/rows_ipa_diacritics.xml
@@ -2,7 +2,7 @@
 <!--
 /*
 **
-** Copyright 2011, The Android Open Source Project
+** Copyright 2026, The Android Open Source Project
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/app/src/main/res/xml/rows_ipa_diacritics.xml
+++ b/app/src/main/res/xml/rows_ipa_diacritics.xml
@@ -2,7 +2,7 @@
 <!--
 /*
 **
-** Copyright 2026, The Android Open Source Project
+** Copyright 2026, lgmventura
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/app/src/main/res/xml/rows_ipa_diacritics.xml
+++ b/app/src/main/res/xml/rows_ipa_diacritics.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+/*
+**
+** Copyright 2011, The Android Open Source Project
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+-->
+
+<merge
+    xmlns:latin="http://schemas.android.com/apk/res-auto"
+>
+    <include
+        latin:keyboardLayout="@xml/key_styles_common" />
+    <include
+        latin:keyboardLayout="@xml/key_styles_currency" />
+    <Row
+        latin:keyWidth="10%p"
+        >
+        <include
+            latin:keyboardLayout="@xml/rowkeys_ipa_diacritics1" />
+    </Row>
+    <Row
+        latin:keyWidth="10%p"
+    >
+        <include
+            latin:keyboardLayout="@xml/rowkeys_ipa_diacritics2"
+            latin:keyXPos="5%p" />
+    </Row>
+    <Row
+        latin:keyWidth="10%p"
+    >
+        <Key
+            latin:keyStyle="toMoreSymbolKeyStyle"
+            latin:keyWidth="14%p" />
+        <include
+            latin:keyXPos="15%p"
+            latin:keyboardLayout="@xml/rowkeys_ipa_diacritics3" />
+        <Key
+            latin:keyStyle="deleteKeyStyle"
+            latin:keyXPos="86%p"
+            latin:keyWidth="14%p" />
+    </Row>
+    <Row
+        latin:keyWidth="10%p"
+        latin:backgroundType="functional"
+    >
+        <Key
+            latin:keyStyle="toAlphaKeyStyle"
+            latin:keyWidth="15%p" />
+        <include
+            latin:keyboardLayout="@xml/row_symbols4" />
+        <Key
+            latin:keyStyle="enterKeyStyle"
+            latin:keyWidth="fillRight" />
+    </Row>
+</merge>

--- a/app/src/main/res/xml/rows_ipa_diacritics_shifted.xml
+++ b/app/src/main/res/xml/rows_ipa_diacritics_shifted.xml
@@ -2,7 +2,7 @@
 <!--
 /*
 **
-** Copyright 2011, The Android Open Source Project
+** Copyright 2026, The Android Open Source Project
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/app/src/main/res/xml/rows_ipa_diacritics_shifted.xml
+++ b/app/src/main/res/xml/rows_ipa_diacritics_shifted.xml
@@ -2,7 +2,7 @@
 <!--
 /*
 **
-** Copyright 2026, The Android Open Source Project
+** Copyright 2026, lgmventura
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/app/src/main/res/xml/rows_ipa_diacritics_shifted.xml
+++ b/app/src/main/res/xml/rows_ipa_diacritics_shifted.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+/*
+**
+** Copyright 2011, The Android Open Source Project
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+-->
+
+<merge
+    xmlns:latin="http://schemas.android.com/apk/res-auto"
+>
+    <include
+        latin:keyboardLayout="@xml/key_styles_common" />
+    <include
+        latin:keyboardLayout="@xml/key_styles_currency" />
+    <Row
+        latin:keyWidth="10%p"
+        >
+        <include
+            latin:keyboardLayout="@xml/rowkeys_ipa_diacritics_shifted1" />
+    </Row>
+    <Row
+        latin:keyWidth="10%p"
+    >
+        <include
+            latin:keyboardLayout="@xml/rowkeys_ipa_diacritics_shifted2"
+            latin:keyXPos="5%p" />
+    </Row>
+    <Row
+        latin:keyWidth="10%p"
+    >
+        <Key
+            latin:keyStyle="toMoreSymbolKeyStyle"
+            latin:keyWidth="14%p" />
+        <include
+            latin:keyXPos="15%p"
+            latin:keyboardLayout="@xml/rowkeys_ipa_diacritics_shifted3" />
+        <Key
+            latin:keyStyle="deleteKeyStyle"
+            latin:keyXPos="86%p"
+            latin:keyWidth="14%p" />
+    </Row>
+    <Row
+        latin:keyWidth="10%p"
+        latin:backgroundType="functional"
+    >
+        <Key
+            latin:keyStyle="toAlphaKeyStyle"
+            latin:keyWidth="15%p" />
+        <include
+            latin:keyboardLayout="@xml/row_symbols4" />
+        <Key
+            latin:keyStyle="enterKeyStyle"
+            latin:keyWidth="fillRight" />
+    </Row>
+</merge>


### PR DESCRIPTION
Adding a new layout and 3 new keyboard pages,for the International Phonetic Alphabet (IPA). To use it, add a new language, select Ipa and confirm it.

Java code modified to permit the use of keyLabel, which can show a different character of set of characters of the one which is typed (keySpec). This is needed to put a dotted circle to show the relative position of the diacritics, for example: ◌̃. This will be in keyLabel, but in keySpec, only ~.